### PR TITLE
feat: added /imdb search and; queue caption edits

### DIFF
--- a/Backend/helper/pyro.py
+++ b/Backend/helper/pyro.py
@@ -145,6 +145,7 @@ async def restart_notification():
 commands = [
     BotCommand("start", "🚀 Start the bot"),
     BotCommand("set", "🎬 Manually add IMDb metadata"),
+    BotCommand("imdb", "🔎 [query] or ttxxxxxx Get IMDB info"),
     BotCommand("channels", "📡 List AUTH channels"),
     BotCommand("addchannel", "➕ Add a channel"),
     BotCommand("removechannel", "➖ Remove a channel"),

--- a/Backend/pyrofork/plugins/imdb_search.py
+++ b/Backend/pyrofork/plugins/imdb_search.py
@@ -1,0 +1,216 @@
+import asyncio
+
+from pyrogram import Client, filters
+from pyrogram.types import (
+    CallbackQuery,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    Message,
+    InputMediaPhoto,
+)
+
+import Backend
+from Backend.helper.custom_filter import CustomFilters
+from Backend.helper.imdb import BASE_URL, _get_client, extract_first_year, get_detail
+from Backend.logger import LOGGER
+
+SEARCH_CACHE = {}
+
+async def search_imdb(query: str) -> list | None:
+    try:
+        client = await _get_client()
+        urls = [
+            f"{BASE_URL}/catalog/movie/imdb/search={query}.json",
+            f"{BASE_URL}/catalog/series/imdb/search={query}.json",
+        ]
+        responses = await asyncio.gather(*(client.get(url) for url in urls))
+
+        results = []
+        seen_ids = set()
+        for response, media_type in zip(responses, ("movie", "tvSeries")):
+            if response.status_code != 200:
+                continue
+            metas = (response.json() or {}).get("metas") or []
+            for meta in metas:
+                imdb_id = meta.get("imdb_id") or meta.get("id")
+                if not imdb_id or imdb_id in seen_ids:
+                    continue
+                year_value = extract_first_year(
+                    meta.get("releaseInfo") or meta.get("year") or meta.get("released")
+                )
+                results.append(
+                    {
+                        "id": imdb_id,
+                        "title": meta.get("name", ""),
+                        "year": year_value or None,
+                        "type": media_type,
+                        "imdb": f"https://www.imdb.com/title/{imdb_id}",
+                    }
+                )
+                seen_ids.add(imdb_id)
+
+        return results
+    except Exception as error:
+        LOGGER.error(f"IMDB Search Error: {error}")
+        return None
+
+
+@Client.on_message(filters.command("imdb") & CustomFilters.owner)
+async def imdb_search(client: Client, message: Message):
+    if len(message.command) < 2:
+        return await message.reply("<i>Usage: /imdb [Movie Name]</i>")
+
+    query = message.text.split(" ", 1)[1].strip()
+    status_message = await message.reply(
+        "<i>Searching...</i>", quote=True
+    )
+
+    results = await search_imdb(query)
+    if not results:
+        return await status_message.edit("<i>No results found.</i>")
+
+    SEARCH_CACHE[status_message.id] = results
+    buttons = [
+        [
+            InlineKeyboardButton(
+                "🎬 Movies",
+                callback_data=f"imdb_filter|movie|{status_message.id}",
+            ),
+            InlineKeyboardButton(
+                "📺 TV Series",
+                callback_data=f"imdb_filter|tvSeries|{status_message.id}",
+            ),
+        ],
+        [InlineKeyboardButton("🚫 Close", callback_data="imdb_close")],
+    ]
+
+    await status_message.edit(
+        f"<b>Select media_type for '{query}'</b>",
+        reply_markup=InlineKeyboardMarkup(buttons),
+    )
+
+
+async def show_details(
+    client: Client, chat_id: int, imdb_id: str, media_type: str, message: Message
+):
+    if media_type == "movie":
+        data = await get_detail(imdb_id=imdb_id, media_type="movie")
+    else:
+        data = await get_detail(imdb_id=imdb_id, media_type="tvSeries")
+    
+    if not data:
+        return await message.edit_text("<i>Failed to fetch details.</i>")
+
+    imdb_url = f"https://www.imdb.com/title/{imdb_id}"
+    is_default = Backend.USE_DEFAULT_ID == imdb_url
+
+    default_text = "Clear Default" if is_default else "Set Default"
+    default_action = "imdb_clear" if is_default else "imdb_set"
+    buttons = [
+        [
+            InlineKeyboardButton(
+                default_text, callback_data=f"{default_action}|{imdb_id}"
+            ),
+            InlineKeyboardButton("🚫 Close", callback_data="imdb_close"),
+        ]
+    ]
+
+    caption = (
+        f"🎬 <b>Title:</b> {data.get('title')}"
+        f"{(' (' + str((data.get('releaseDetailed') or {}).get('year')) + ')') if (data.get('releaseDetailed') or {}).get('year') else ''}\n"
+        f"🎞️ <b>Type:</b> {data.get('type')}\n"
+        f"🎭 <b>Cast:</b> {(', '.join(data.get('cast')) if isinstance(data.get('cast'), list) else (data.get('cast') or ''))}\n"
+        f"🎯 <b>Genre:</b> {(', '.join(data.get('genres')) if isinstance(data.get('genres'), list) else (', '.join(data.get('genre')) if isinstance(data.get('genre'), list) else (data.get('genres') or data.get('genre') or '')))}\n"
+        f"📽️ <b>Director:</b> {(', '.join(data.get('director')) if isinstance(data.get('director'), list) else (data.get('director') or ''))}\n"
+        f"⭐ <b>Rating:</b> {((data.get('rating') or data.get('imdbRating') or '') if not isinstance((data.get('rating') or data.get('imdbRating') or ''), dict) else (((data.get('rating') or data.get('imdbRating') or {}).get('star') or (data.get('rating') or data.get('imdbRating') or {}).get('value') or '')))}\n"
+        f"⏱️ <b>Runtime:</b> {data.get('runtime', '')}\n"
+        f"🔗 <b>IMDb URL:</b> {imdb_url}\n\n"
+        f"📜 <b>Plot:</b> <code>{data.get('plot', '')}</code>"
+    )
+    
+    poster_url = data.get("poster")
+    try:
+        if poster_url:
+            await message.edit_media(
+                media=InputMediaPhoto(media=poster_url, caption=caption),
+                reply_markup=InlineKeyboardMarkup(buttons),
+            )
+        else:
+            await message.edit_text(
+                caption,
+                reply_markup=InlineKeyboardMarkup(buttons),
+            )
+    except Exception as error:
+        LOGGER.error(f"Show details error: {error}")
+
+
+@Client.on_callback_query(filters.regex(r"^imdb_"))
+async def imdb_callback(client: Client, callback_query: CallbackQuery):
+    action, *extra = callback_query.data.split("|")
+    imdb_id = extra[0] if extra else None
+    media_type = extra[1] if len(extra) > 1 else None
+
+    if action == "imdb_close":
+        await callback_query.message.delete()
+        return
+
+    if action == "imdb_filter":
+        selected_media_type, message_id = extra[0], int(extra[1])
+
+        results = [
+            result for result in SEARCH_CACHE.get(message_id, [])
+            if result["type"] == selected_media_type
+        ][:10]
+        
+        if not results:
+            return await callback_query.answer("No results found", show_alert=True)
+
+        buttons = [
+            [
+                InlineKeyboardButton(
+                    (
+                        f"🎬 {result['title']} ({result['year']})"
+                        if result.get("year")
+                        else f"🎬 {result['title']}"
+                    ),
+                    callback_data=f"imdb_view|{result['id']}|{result['type']}",
+                )
+            ]
+            for result in results
+        ]
+        buttons.append([InlineKeyboardButton("🚫 Close", callback_data="imdb_close")])
+
+        await callback_query.message.edit(
+            f"<b>Found {len(results)} {selected_media_type} results</b>",
+            reply_markup=InlineKeyboardMarkup(buttons),
+        )
+
+        await callback_query.answer()
+        return
+
+    if action == "imdb_view":
+        await callback_query.answer()
+        await show_details(
+            client, callback_query.message.chat.id, imdb_id, media_type, callback_query.message
+        )
+        return
+
+    if action in ("imdb_set", "imdb_clear"):
+        is_set = action == "imdb_set"
+        Backend.USE_DEFAULT_ID = (
+            f"https://www.imdb.com/title/{imdb_id}" if is_set else None
+        )
+        default_text = "Clear Default" if is_set else "Set Default"
+        default_action = "imdb_clear" if is_set else "imdb_set"
+        buttons = [
+            [
+                InlineKeyboardButton(
+                    default_text, callback_data=f"{default_action}|{imdb_id}"
+                ),
+                InlineKeyboardButton("🚫 Close", callback_data="imdb_close"),
+            ]
+        ]
+        await callback_query.answer(f"Default IMDB {'set' if is_set else 'cleared'}")
+        await callback_query.message.edit_reply_markup(
+            reply_markup=InlineKeyboardMarkup(buttons)
+        )

--- a/Backend/pyrofork/plugins/reciever.py
+++ b/Backend/pyrofork/plugins/reciever.py
@@ -13,6 +13,7 @@ from pyrogram.enums.parse_mode import ParseMode
 
 
 file_queue = Queue()
+edit_queue = Queue()
 db_lock = Lock()
 
 async def process_file():
@@ -26,8 +27,30 @@ async def process_file():
                 LOGGER.info("Update failed due to validation errors.")
         file_queue.task_done()
 
+async def process_edit():
+    while True:
+        chat_id, msg_id, new_caption, log_msg = await edit_queue.get()
+        try:
+            await asleep(5)
+            LOGGER.info(f"Editing Caption for Message ID: {msg_id}: {log_msg}")
+            await edit_message(
+                chat_id=chat_id,
+                msg_id=msg_id,
+                new_caption=new_caption
+            )
+        except FloodWait as e:
+            LOGGER.warning(f"FloodWait {e.value}s while editing")
+            await asleep(e.value)
+        except Exception as e:
+            LOGGER.error(f"Edit failed for {msg_id}: {e}")
+        finally:
+            edit_queue.task_done()
+
 for _ in range(1):
     create_task(process_file())
+
+for _ in range(1):
+    create_task(process_edit())
 
 
 @Client.on_message(filters.channel & (filters.document | filters.video))
@@ -46,16 +69,19 @@ async def file_receive_handler(client: Client, message: Message):
                     LOGGER.warning(f"Metadata failed for file: {title} (ID: {msg_id})")
                     return
 
-                title = remove_urls(title)
+                original_title = title
+                title = (title.split('.mkv')[0] + '.mkv') if '.mkv' in title else (title.split('.mp4')[0] + '.mp4') if '.mp4' in title else title
                 if not title.endswith(('.mkv', '.mp4')):
                     title += '.mkv'
 
-                if Backend.USE_DEFAULT_ID:
-                    new_caption = (message.caption + "\n\n" + Backend.USE_DEFAULT_ID) if message.caption else Backend.USE_DEFAULT_ID
-                    create_task(edit_message(
-                        chat_id=message.chat.id,
-                        msg_id=message.id,
-                        new_caption=new_caption
+                if title != original_title or Backend.USE_DEFAULT_ID:
+                    new_caption = (title + "\n\n" + Backend.USE_DEFAULT_ID) if Backend.USE_DEFAULT_ID else title
+                    log_msg = f"{metadata_info.get('title')} S{metadata_info.get('season_number')}E{metadata_info.get('episode_number')}" if metadata_info.get('season_number') else f"{metadata_info.get('title')} ({metadata_info.get('year')})"
+                    await edit_queue.put((
+                        message.chat.id,
+                        message.id,
+                        new_caption,
+                        log_msg
                     ))
 
                 await file_queue.put((metadata_info, int(channel), msg_id, size, title))
@@ -71,68 +97,3 @@ async def file_receive_handler(client: Client, message: Message):
             )
     else:
         await message.reply_text("> Channel is not in AUTH_CHANNEL")
-        
-
-@Client.on_edited_message(filters.channel & (filters.document | filters.video))
-async def file_edited_handler(client: Client, message: Message):
-    if str(message.chat.id) in Telegram.AUTH_CHANNEL:
-        try:
-            if message.video or (message.document and message.document.mime_type.startswith("video/")):
-                file = message.video or message.document
-                title = message.caption or file.file_name
-                msg_id = message.id
-                size = get_readable_file_size(file.file_size)
-                channel = str(message.chat.id).replace("-100", "")
-
-                from Backend.helper.metadata import extract_default_id
-                override_id = extract_default_id(message.caption) if message.caption else None
-
-                # Only proceed if we found a valid manual overide ID in the caption update
-                if override_id:
-                    LOGGER.info(f"Detected override ID '{override_id}' in edited message {msg_id}")
-                    
-                    from Backend.helper.encrypt import encode_string
-                    stream_id_hash = await encode_string({"chat_id": int(channel), "msg_id": msg_id})
-                    
-                    # Wipe the old streaming quality reference from the old associated media
-                    await db.delete_media_by_stream_id(stream_id_hash)
-
-                    # Reprocess metadata completely
-                    metadata_info = await metadata(clean_filename(title), int(channel), msg_id, override_id=override_id)
-                    if metadata_info is None:
-                        LOGGER.warning(f"Metadata failed for edited file: {title} (ID: {msg_id})")
-                        return
-
-                    title = remove_urls(title)
-                    if not title.endswith(('.mkv', '.mp4')):
-                        title += '.mkv'
-
-                    # Add the new quality to the correct DB movie/show
-                    await file_queue.put((metadata_info, int(channel), msg_id, size, title))
-            else:
-                pass # ignore edits on other types
-        except Exception as e:
-            LOGGER.error(f"Error handling edited generic file {message.id}: {e}")
-
-@Client.on_deleted_messages(filters.channel)
-async def file_deleted_handler(client: Client, messages: list[Message]):
-    # pyrogram provides a list of deleted messages.
-    try:
-        from Backend.helper.encrypt import encode_string
-        
-        for message in messages:
-            if message.chat and str(message.chat.id) in Telegram.AUTH_CHANNEL:
-                channel = str(message.chat.id).replace("-100", "")
-                msg_id = message.id
-                
-                try:
-                    stream_id_hash = await encode_string({"chat_id": int(channel), "msg_id": msg_id})
-                    deleted = await db.delete_media_by_stream_id(stream_id_hash)
-                    
-                    if deleted:
-                        LOGGER.info(f"Automatically purged deleted message {msg_id} from database.")
-                except Exception as ex:
-                    LOGGER.error(f"Failed to scrub deleted message {msg_id}: {ex}")
-                    
-    except Exception as e:
-        LOGGER.error(f"Error handling deleted messages: {e}")


### PR DESCRIPTION
- Added IMDb integration to the bot:
  - Add owner-only `/imdb` search with inline buttons to filter Movie/TV results and view full IMDb details (poster + metadata).
  - Allow setting/clearing a default IMDb URL (`Backend.USE_DEFAULT_ID`) from the IMDb details view.

- Refactored message edit flow:
  - Removed old AUTH_CHANNEL file edit/delete handlers.
  - Improve receiver caption editing by introducing an edit queue with throttling + FloodWait handling and normalizing `.mkv`/`.mp4` filenames before editing.