### PR TITLE
Add opt-in IPTV Live TV catalog

### DIFF
--- a/Backend/__main__.py
+++ b/Backend/__main__.py
@@ -20,6 +20,10 @@ from Backend.helper.auto_catalog import (
     AUTO_SYNC_DELAY_SECONDS, AUTO_CATALOG_ON_STARTUP,
     AUTO_CATALOG_FULL_REBUILD_ON_STARTUP
 )
+from Backend.helper.iptv import (
+    start_iptv_interval_loop,
+    start_iptv_sync_background,
+)
 
 
 loop = get_event_loop()
@@ -68,6 +72,14 @@ async def start_services():
             ))
 
         loop.create_task(start_auto_catalog_interval_loop(db))
+
+        if Telegram.IPTV_ENABLED and Telegram.IPTV_AUTO_SYNC:
+            loop.create_task(start_iptv_sync_background(
+                db,
+                force=False,
+                delay_seconds=Telegram.IPTV_SYNC_START_DELAY_SECONDS,
+            ))
+            loop.create_task(start_iptv_interval_loop(db))
         
         if Telegram.SUBSCRIPTION:
             loop.create_task(subscription_checker_loop(StreamBot))

--- a/Backend/config.py
+++ b/Backend/config.py
@@ -28,6 +28,38 @@ class Telegram:
     REPLACE_MODE = getenv("REPLACE_MODE", "true").lower() == "true"
     HIDE_CATALOG = getenv("HIDE_CATALOG", "false").lower() == "true"
 
+    # IPTV live TV (iptv-org, India v1)
+    IPTV_ENABLED = getenv("IPTV_ENABLED", "false").lower() == "true"
+    IPTV_COUNTRY_CODES = [
+        code.strip().upper()
+        for code in getenv("IPTV_COUNTRY_CODES", "IN").split(",")
+        if code.strip()
+    ] or ["IN"]
+    try:
+        IPTV_PAGE_SIZE = max(1, min(100, int(getenv("IPTV_PAGE_SIZE", "50") or 50)))
+    except Exception:
+        IPTV_PAGE_SIZE = 50
+    IPTV_AUTO_SYNC = getenv("IPTV_AUTO_SYNC", "true").lower() == "true"
+    try:
+        IPTV_SYNC_INTERVAL_MINUTES = max(30, int(getenv("IPTV_SYNC_INTERVAL_MINUTES", "360") or 360))
+    except Exception:
+        IPTV_SYNC_INTERVAL_MINUTES = 360
+    try:
+        IPTV_SYNC_START_DELAY_SECONDS = max(0, int(getenv("IPTV_SYNC_START_DELAY_SECONDS", "30") or 30))
+    except Exception:
+        IPTV_SYNC_START_DELAY_SECONDS = 30
+    try:
+        IPTV_REQUEST_TIMEOUT_SEC = max(5.0, float(getenv("IPTV_REQUEST_TIMEOUT_SEC", "45") or 45))
+    except Exception:
+        IPTV_REQUEST_TIMEOUT_SEC = 45.0
+    try:
+        IPTV_PROXY_TIMEOUT_SEC = max(5.0, float(getenv("IPTV_PROXY_TIMEOUT_SEC", "30") or 30))
+    except Exception:
+        IPTV_PROXY_TIMEOUT_SEC = 30.0
+    IPTV_PROXY_FALLBACK_ENABLED = getenv("IPTV_PROXY_FALLBACK_ENABLED", "true").lower() == "true"
+    IPTV_PROXY_SECRET = getenv("IPTV_PROXY_SECRET", "").strip()
+    IPTV_API_BASE_URL = getenv("IPTV_API_BASE_URL", "https://iptv-org.github.io/api").rstrip("/")
+
     ADMIN_USERNAME = getenv("ADMIN_USERNAME", "fyvio")
     ADMIN_PASSWORD = getenv("ADMIN_PASSWORD", "fyvio")
     

--- a/Backend/fastapi/main.py
+++ b/Backend/fastapi/main.py
@@ -8,11 +8,12 @@ from Backend import __version__
 from Backend.fastapi.security.credentials import require_auth
 from Backend.fastapi.routes.stream_routes import router as stream_router, decay_client_failures
 from Backend.fastapi.routes.stremio_routes import router as stremio_router
+from Backend.fastapi.routes.iptv_routes import router as iptv_router
 from Backend.fastapi.routes.template_routes import (
     login_page, login_post, logout, set_theme, dashboard_page,
     media_management_page, edit_media_page, public_status_page, stremio_guide_page,
     admin_dashboard_page, admin_subscriptions_page, admin_access_page,
-    custom_catalogs_page
+    custom_catalogs_page, live_tv_page
 )
 from Backend.fastapi.routes.api_routes import (
     list_media_api, delete_media_api, update_media_api,
@@ -31,7 +32,9 @@ from Backend.fastapi.routes.api_routes import (
     delete_custom_catalog_api, get_custom_catalog_items_api, search_catalog_media_api,
     add_custom_catalog_item_api, remove_custom_catalog_item_api,
     auto_sync_custom_catalogs_api, auto_catalog_sync_status_api,
-    get_auto_catalog_settings_api, update_auto_catalog_settings_api
+    get_auto_catalog_settings_api, update_auto_catalog_settings_api,
+    get_iptv_status_api, sync_iptv_api, list_iptv_channels_api,
+    update_iptv_channel_api, get_iptv_settings_api, update_iptv_settings_api
 )
 
 templates = Jinja2Templates(directory="Backend/fastapi/templates")
@@ -65,6 +68,7 @@ async def _startup():
 # --- Include existing API routers ---
 app.include_router(stream_router)
 app.include_router(stremio_router)
+app.include_router(iptv_router)
 
 # --- Public Routes (No Authentication Required) ---
 @app.get("/login", response_class=HTMLResponse)
@@ -109,9 +113,56 @@ async def media_management(request: Request, media_type: str = "movie", _: bool 
 async def custom_catalogs(request: Request, _: bool = Depends(require_auth)):
     return await custom_catalogs_page(request, _)
 
+
+@app.get("/live-tv", response_class=HTMLResponse)
+async def live_tv(request: Request, _: bool = Depends(require_auth)):
+    return await live_tv_page(request, _)
+
+
 @app.get("/media/edit", response_class=HTMLResponse)
 async def edit_media(request: Request, tmdb_id: int, db_index: int, media_type: str, _: bool = Depends(require_auth)):
     return await edit_media_page(request, tmdb_id, db_index, media_type, _)
+
+
+@app.get("/api/iptv/status")
+async def get_iptv_status(_: bool = Depends(require_auth)):
+    return await get_iptv_status_api()
+
+
+@app.post("/api/iptv/sync")
+async def sync_iptv(force: bool = True, _: bool = Depends(require_auth)):
+    return await sync_iptv_api(force)
+
+
+@app.get("/api/iptv/channels")
+async def get_iptv_channels(
+    search: str = "",
+    hidden: bool | None = None,
+    page: int = 1,
+    page_size: int = 50,
+    _: bool = Depends(require_auth),
+):
+    return await list_iptv_channels_api(search, hidden, page, page_size)
+
+
+@app.patch("/api/iptv/channels/{channel_id}")
+async def update_iptv_channel(
+    channel_id: str,
+    payload: dict,
+    _: bool = Depends(require_auth),
+):
+    return await update_iptv_channel_api(channel_id, payload)
+
+
+@app.get("/api/iptv/settings")
+async def get_iptv_settings_route(_: bool = Depends(require_auth)):
+    return await get_iptv_settings_api()
+
+
+@app.put("/api/iptv/settings")
+async def update_iptv_settings_route(payload: dict, _: bool = Depends(require_auth)):
+    return await update_iptv_settings_api(payload)
+
 
 @app.get("/api/media/list")
 async def list_media(

--- a/Backend/fastapi/routes/api_routes.py
+++ b/Backend/fastapi/routes/api_routes.py
@@ -20,6 +20,14 @@ from Backend.helper.auto_catalog import (
     get_auto_catalog_settings,
     update_auto_catalog_settings,
 )
+from Backend.helper.iptv import (
+    get_iptv_settings,
+    get_iptv_sync_status,
+    list_iptv_channels,
+    set_iptv_channel_hidden,
+    start_iptv_sync_background,
+    update_iptv_settings,
+)
 
 
 # --- API Routes for System Stats ---
@@ -50,6 +58,71 @@ async def get_system_stats_api():
             "server_status": "error", 
             "error": str(e)
         }
+
+
+# --- IPTV Live TV Administration ---
+
+async def get_iptv_status_api():
+    try:
+        return await get_iptv_sync_status(db)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def sync_iptv_api(force: bool = True):
+    try:
+        result = await start_iptv_sync_background(db, force=force)
+        if not result.get("started") and result.get("reason") == "sync_already_running":
+            raise HTTPException(status_code=409, detail="IPTV sync is already running.")
+        return result
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def list_iptv_channels_api(
+    search: str = "",
+    hidden: bool | None = None,
+    page: int = 1,
+    page_size: int = 50,
+):
+    try:
+        return await list_iptv_channels(
+            db,
+            search=search,
+            hidden=hidden,
+            page=page,
+            page_size=page_size,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def update_iptv_channel_api(channel_id: str, payload: dict):
+    if "hidden" not in payload:
+        raise HTTPException(status_code=400, detail="hidden is required.")
+    hidden = bool(payload.get("hidden"))
+    updated = await set_iptv_channel_hidden(db, channel_id, hidden)
+    if not updated:
+        raise HTTPException(status_code=404, detail="IPTV channel not found.")
+    return {"success": True, "channel_id": channel_id, "hidden": hidden}
+
+
+async def get_iptv_settings_api():
+    try:
+        return await get_iptv_settings(db)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+async def update_iptv_settings_api(payload: dict):
+    try:
+        return await update_iptv_settings(db, payload)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
     
 # --- API Routes for Media Management ---
 

--- a/Backend/fastapi/routes/iptv_routes.py
+++ b/Backend/fastapi/routes/iptv_routes.py
@@ -1,0 +1,260 @@
+import ipaddress
+import re
+from urllib.parse import urljoin, urlparse
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from fastapi.responses import StreamingResponse
+
+from Backend import db
+from Backend.config import Telegram
+from Backend.fastapi.security.tokens import verify_token
+from Backend.helper.iptv import (
+    get_iptv_channel_by_stream,
+    sign_proxy_target,
+    verify_proxy_target,
+)
+
+
+router = APIRouter(prefix="/iptv", tags=["IPTV Streaming"])
+
+HLS_CONTENT_TYPES = {
+    "application/vnd.apple.mpegurl",
+    "application/x-mpegurl",
+    "audio/mpegurl",
+    "audio/x-mpegurl",
+}
+PASSTHROUGH_HEADERS = {
+    "accept-ranges",
+    "cache-control",
+    "content-length",
+    "content-range",
+    "content-type",
+    "etag",
+    "expires",
+    "last-modified",
+}
+URI_ATTRIBUTE_PATTERN = re.compile(r'URI=(["\'])(.+?)\1')
+
+
+def _ensure_proxy_access(token_data: dict) -> None:
+    if token_data.get("subscription_expired"):
+        raise HTTPException(status_code=403, detail="Subscription expired")
+    if token_data.get("limit_exceeded"):
+        raise HTTPException(status_code=429, detail="Streaming limit reached")
+
+
+def _safe_target_url(url: str) -> str:
+    parsed = urlparse(str(url or ""))
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.hostname:
+        raise HTTPException(status_code=400, detail="Unsupported IPTV URL")
+    hostname = parsed.hostname.lower()
+    if hostname in {"localhost", "localhost.localdomain"}:
+        raise HTTPException(status_code=400, detail="Invalid IPTV host")
+    try:
+        address = ipaddress.ip_address(hostname)
+        if (
+            address.is_private
+            or address.is_loopback
+            or address.is_link_local
+            or address.is_multicast
+            or address.is_reserved
+        ):
+            raise HTTPException(status_code=400, detail="Invalid IPTV host")
+    except ValueError:
+        pass
+    return url
+
+
+def _source_from_channel(channel: dict, stream_id: str) -> dict:
+    for source in channel.get("streams") or []:
+        if str(source.get("id")) == str(stream_id):
+            return source
+    raise HTTPException(status_code=404, detail="IPTV stream not found")
+
+
+def _request_headers(request: Request, source: dict) -> dict:
+    headers = {
+        "Accept": request.headers.get("accept", "*/*"),
+        "Accept-Encoding": "identity",
+    }
+    if request.headers.get("range"):
+        headers["Range"] = request.headers["range"]
+    for name, value in (source.get("request_headers") or {}).items():
+        if value:
+            headers[str(name)] = str(value)
+    if "User-Agent" not in headers:
+        headers["User-Agent"] = request.headers.get(
+            "user-agent",
+            "Telegram-Stremio-IPTV/1.0",
+        )
+    return headers
+
+
+def _response_headers(upstream: httpx.Response, *, rewritten: bool = False) -> dict:
+    headers = {
+        name: value
+        for name, value in upstream.headers.items()
+        if name.lower() in PASSTHROUGH_HEADERS
+    }
+    if rewritten:
+        headers.pop("content-length", None)
+        headers.pop("content-range", None)
+        headers["Content-Type"] = "application/vnd.apple.mpegurl"
+        headers["Cache-Control"] = "no-store"
+    return headers
+
+
+def _is_hls(url: str, response: httpx.Response) -> bool:
+    content_type = response.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+    path = urlparse(url).path.lower()
+    return content_type in HLS_CONTENT_TYPES or path.endswith(".m3u8")
+
+
+def _rewrite_hls_manifest(content: str, base_url: str, token: str, stream_id: str) -> str:
+    def proxied(value: str) -> str:
+        target = _safe_target_url(urljoin(base_url, value.strip()))
+        signed = sign_proxy_target(stream_id, target)
+        return f"{Telegram.BASE_URL}/iptv/{token}/fetch/{signed}"
+
+    output = []
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            output.append(line)
+            continue
+        if stripped.startswith("#"):
+            def replace_uri(match):
+                quote = match.group(1)
+                return f"URI={quote}{proxied(match.group(2))}{quote}"
+
+            output.append(URI_ATTRIBUTE_PATTERN.sub(replace_uri, line))
+            continue
+        output.append(proxied(stripped))
+    return "\n".join(output) + ("\n" if content.endswith("\n") else "")
+
+
+async def _proxy(
+    request: Request,
+    *,
+    token: str,
+    stream_id: str,
+    target_url: str,
+    source: dict,
+):
+    target_url = _safe_target_url(target_url)
+    client = httpx.AsyncClient(
+        timeout=httpx.Timeout(Telegram.IPTV_PROXY_TIMEOUT_SEC),
+        follow_redirects=True,
+    )
+    method = request.method.upper()
+    headers = _request_headers(request, source)
+
+    try:
+        upstream_request = client.build_request(method, target_url, headers=headers)
+        upstream = await client.send(upstream_request, stream=True)
+        if method == "HEAD" and upstream.status_code in {405, 501}:
+            await upstream.aclose()
+            headers["Range"] = "bytes=0-0"
+            upstream_request = client.build_request("GET", target_url, headers=headers)
+            upstream = await client.send(upstream_request, stream=True)
+
+        if method == "HEAD":
+            response_headers = _response_headers(upstream)
+            status_code = upstream.status_code
+            await upstream.aclose()
+            await client.aclose()
+            return Response(status_code=status_code, headers=response_headers)
+
+        if _is_hls(str(upstream.url), upstream):
+            raw = await upstream.aread()
+            await upstream.aclose()
+            await client.aclose()
+            if len(raw) > 2 * 1024 * 1024:
+                raise HTTPException(status_code=502, detail="IPTV playlist is unexpectedly large")
+            encoding = upstream.encoding or "utf-8"
+            manifest = raw.decode(encoding, errors="replace")
+            rewritten = _rewrite_hls_manifest(
+                manifest,
+                str(upstream.url),
+                token,
+                stream_id,
+            )
+            return Response(
+                content=rewritten,
+                status_code=upstream.status_code,
+                headers=_response_headers(upstream, rewritten=True),
+                media_type="application/vnd.apple.mpegurl",
+            )
+
+        async def body_iterator():
+            try:
+                async for chunk in upstream.aiter_raw():
+                    yield chunk
+            finally:
+                await upstream.aclose()
+                await client.aclose()
+
+        return StreamingResponse(
+            body_iterator(),
+            status_code=upstream.status_code,
+            headers=_response_headers(upstream),
+            media_type=upstream.headers.get("content-type"),
+        )
+    except HTTPException:
+        await client.aclose()
+        raise
+    except httpx.TimeoutException as exc:
+        await client.aclose()
+        raise HTTPException(status_code=504, detail="IPTV upstream timed out") from exc
+    except httpx.HTTPError as exc:
+        await client.aclose()
+        raise HTTPException(status_code=502, detail="IPTV upstream request failed") from exc
+
+
+@router.api_route("/{token}/stream/{stream_id}", methods=["GET", "HEAD"])
+async def proxy_iptv_stream(
+    request: Request,
+    token: str,
+    stream_id: str,
+    token_data: dict = Depends(verify_token),
+):
+    _ensure_proxy_access(token_data)
+    channel = await get_iptv_channel_by_stream(db, stream_id)
+    if not channel:
+        raise HTTPException(status_code=404, detail="IPTV stream not found")
+    source = _source_from_channel(channel, stream_id)
+    return await _proxy(
+        request,
+        token=token,
+        stream_id=stream_id,
+        target_url=source.get("url"),
+        source=source,
+    )
+
+
+@router.api_route("/{token}/fetch/{signed_target}", methods=["GET", "HEAD"])
+async def proxy_iptv_child_resource(
+    request: Request,
+    token: str,
+    signed_target: str,
+    token_data: dict = Depends(verify_token),
+):
+    _ensure_proxy_access(token_data)
+    try:
+        payload = verify_proxy_target(signed_target)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    stream_id = str(payload["s"])
+    channel = await get_iptv_channel_by_stream(db, stream_id)
+    if not channel:
+        raise HTTPException(status_code=404, detail="IPTV stream not found")
+    source = _source_from_channel(channel, stream_id)
+    return await _proxy(
+        request,
+        token=token,
+        stream_id=stream_id,
+        target_url=payload["u"],
+        source=source,
+    )

--- a/Backend/fastapi/routes/stremio_routes.py
+++ b/Backend/fastapi/routes/stremio_routes.py
@@ -6,6 +6,15 @@ from Backend import db, __version__
 import PTN
 from datetime import datetime, timezone, timedelta
 from Backend.fastapi.security.tokens import verify_token
+from Backend.helper.iptv import (
+    IPTV_CATALOG_ID,
+    IPTV_ID_PREFIX,
+    build_iptv_streams,
+    get_iptv_channel,
+    get_iptv_settings,
+    iptv_meta,
+    list_iptv_channels,
+)
 
 
 # --- Configuration ---
@@ -185,10 +194,35 @@ async def get_manifest(token: str, token_data: dict = Depends(verify_token)):
         except Exception:
             pass
 
+        try:
+            iptv_settings = await get_iptv_settings(db)
+            if iptv_settings.get("enabled"):
+                iptv_genres = await db.dbs["tracking"]["iptv_channels"].distinct(
+                    "categories",
+                    {"hidden": {"$ne": True}},
+                )
+                catalogs.append({
+                    "type": "tv",
+                    "id": IPTV_CATALOG_ID,
+                    "name": "Live TV - India",
+                    "extra": [
+                        {
+                            "name": "genre",
+                            "isRequired": False,
+                            "options": sorted(str(item) for item in iptv_genres if item),
+                        },
+                        {"name": "skip"},
+                        {"name": "search", "isRequired": False},
+                    ],
+                    "extraSupported": ["genre", "skip", "search"],
+                })
+        except Exception:
+            pass
+
 
     # Build dynamic name/description/version with subscription info
     addon_name = ADDON_NAME
-    addon_desc = "Streams movies and series from your Telegram."
+    addon_desc = "Streams movies, series, and live TV."
     addon_version = ADDON_VERSION
     expiry_obj = None
 
@@ -205,7 +239,7 @@ async def get_manifest(token: str, token_data: dict = Depends(verify_token)):
                         addon_name = f"{ADDON_NAME} — Expires {expiry_str}"
                         addon_desc = (
                             f"📅 Subscription active until {expiry_str}.\n"
-                            f"Streams movies and series from your Telegram."
+                            f"Streams movies, series, and live TV."
                         )
                         # Encode expiry epoch (low 16 bits, hex) into version so
                         # Stremio detects a change when subscription is updated.
@@ -213,7 +247,7 @@ async def get_manifest(token: str, token_data: dict = Depends(verify_token)):
                         addon_version = f"{ADDON_VERSION}-{epoch_tag}"
                     else:
                         addon_name = f"{ADDON_NAME} — Active"
-                        addon_desc = "✅ Subscription active.\nStreams movies and series from your Telegram."
+                        addon_desc = "✅ Subscription active.\nStreams movies, series, and live TV."
             except Exception:
                 pass  # Fallback to defaults on error
 
@@ -226,10 +260,10 @@ async def get_manifest(token: str, token_data: dict = Depends(verify_token)):
         "name": addon_name,
         "logo": "https://i.postimg.cc/XqWnmDXr/Picsart-25-10-09-08-09-45-867.png",
         "description": addon_desc,
-        "types": ["movie", "series"],
+        "types": ["movie", "series", "tv"],
         "resources": resources,
         "catalogs": catalogs,
-        "idPrefixes": ["tt"],
+        "idPrefixes": ["tt", IPTV_ID_PREFIX],
         "behaviorHints": {
             "configurable": True,
             "configurationRequired": False
@@ -410,7 +444,7 @@ async def get_catalog(token: str, media_type: str, id: str, extra: Optional[str]
     if Telegram.HIDE_CATALOG:
         raise HTTPException(status_code=404, detail="Catalog disabled")
 
-    if media_type not in ["movie", "series"]:
+    if media_type not in ["movie", "series", "tv"]:
         raise HTTPException(status_code=404, detail="Invalid catalog type")
 
     genre_filter = None
@@ -431,6 +465,22 @@ async def get_catalog(token: str, media_type: str, id: str, extra: Optional[str]
                     stremio_skip = 0
 
     page = (stremio_skip // PAGE_SIZE) + 1
+
+    if media_type == "tv":
+        if id != IPTV_CATALOG_ID:
+            raise HTTPException(status_code=404, detail="Unknown live TV catalog")
+        settings = await get_iptv_settings(db)
+        if not settings.get("enabled"):
+            return {"metas": []}
+        data = await list_iptv_channels(
+            db,
+            search=search_query or "",
+            category=genre_filter or "",
+            hidden=False,
+            page=(stremio_skip // int(Telegram.IPTV_PAGE_SIZE)) + 1,
+            page_size=int(Telegram.IPTV_PAGE_SIZE),
+        )
+        return {"metas": [iptv_meta(item) for item in data.get("channels", [])]}
 
     try:
         if id.startswith("custom_"):
@@ -477,6 +527,12 @@ async def get_catalog(token: str, media_type: str, id: str, extra: Optional[str]
 async def get_meta(token: str, media_type: str, id: str, token_data: dict = Depends(verify_token)):
     if Telegram.HIDE_CATALOG:
         raise HTTPException(status_code=404, detail="Catalog disabled")
+
+    if media_type == "tv" and id.startswith(IPTV_ID_PREFIX):
+        channel_id = id.removeprefix(IPTV_ID_PREFIX)
+        channel = await get_iptv_channel(db, channel_id)
+        return {"meta": iptv_meta(channel) if channel else {}}
+
     try:
         imdb_id = id
     except (ValueError, IndexError):
@@ -573,6 +629,14 @@ async def get_streams(
                 }
             ]
         }
+
+    if media_type == "tv" and id.startswith(IPTV_ID_PREFIX):
+        settings = await get_iptv_settings(db)
+        if not settings.get("enabled"):
+            return {"streams": []}
+        channel_id = id.removeprefix(IPTV_ID_PREFIX)
+        channel = await get_iptv_channel(db, channel_id)
+        return {"streams": build_iptv_streams(channel, token) if channel else []}
 
 
     try:

--- a/Backend/fastapi/routes/template_routes.py
+++ b/Backend/fastapi/routes/template_routes.py
@@ -281,3 +281,17 @@ async def custom_catalogs_page(request: Request, _: bool = Depends(require_auth)
         "current_theme": theme_name,
         "current_user": current_user,
     })
+
+
+async def live_tv_page(request: Request, _: bool = Depends(require_auth)):
+    theme_name = request.session.get("theme", "dark_professional")
+    theme = get_theme(theme_name)
+    current_user = get_current_user(request)
+
+    return templates.TemplateResponse("live_tv.html", {
+        "request": request,
+        "theme": theme,
+        "themes": get_all_themes(),
+        "current_theme": theme_name,
+        "current_user": current_user,
+    })

--- a/Backend/fastapi/templates/base.html
+++ b/Backend/fastapi/templates/base.html
@@ -198,6 +198,7 @@ tailwind.config = {
         <a href="/" class="nav-link">Home</a>
         <a href="/media/manage" class="nav-link">Media</a>
         <a href="/catalogs" class="nav-link">Catalogs</a>
+        <a href="/live-tv" class="nav-link">TV</a>
         <a href="/admin/dashboard" class="nav-link">Admin</a>
         <a href="/admin/subscriptions" class="nav-link">Subs</a>
         <a href="/admin/access" class="nav-link">Access</a>
@@ -251,6 +252,7 @@ tailwind.config = {
             <a href="/" class="px-4 py-3 rounded-xl hover:bg-primary hover:text-background transition flex items-center gap-3 font-semibold"><i class="fa-solid fa-house"></i> Home</a>
             <a href="/media/manage" class="px-4 py-3 rounded-xl hover:bg-primary hover:text-background transition flex items-center gap-3 font-semibold"><i class="fa-solid fa-clapperboard"></i> Media</a>
             <a href="/catalogs" class="px-4 py-3 rounded-xl hover:bg-primary hover:text-background transition flex items-center gap-3 font-semibold"><i class="fa-solid fa-layer-group"></i> Catalogs</a>
+            <a href="/live-tv" class="px-4 py-3 rounded-xl hover:bg-primary hover:text-background transition flex items-center gap-3 font-semibold"><i class="fa-solid fa-tower-broadcast"></i> Live TV</a>
             <a href="/admin/dashboard" class="px-4 py-3 rounded-xl hover:bg-primary hover:text-background transition flex items-center gap-3 font-semibold"><i class="fa-solid fa-chart-line"></i> Admin</a>
             <a href="/admin/subscriptions" class="px-4 py-3 rounded-xl hover:bg-primary hover:text-background transition flex items-center gap-3 font-semibold"><i class="fa-solid fa-credit-card"></i> Subs</a>
             <a href="/admin/access" class="px-4 py-3 rounded-xl hover:bg-primary hover:text-background transition flex items-center gap-3 font-semibold"><i class="fa-solid fa-shield"></i> Access</a>

--- a/Backend/fastapi/templates/live_tv.html
+++ b/Backend/fastapi/templates/live_tv.html
@@ -1,0 +1,401 @@
+{% extends "base.html" %}
+
+{% block title %}Live TV - TG Stremio{% endblock %}
+
+{% block content %}
+<div class="space-y-6">
+    <section class="glass-panel rounded-[2.5rem] p-6 sm:p-8">
+        <div class="flex flex-col xl:flex-row xl:items-center xl:justify-between gap-6">
+            <div>
+                <div class="flex items-center gap-3 text-[10px] font-bold uppercase tracking-[0.22em] text-text-secondary">
+                    <span class="w-2 h-2 rounded-full bg-primary shadow-[0_0_12px_var(--primary)]"></span>
+                    iptv-org India
+                </div>
+                <h1 class="mt-3 text-2xl sm:text-3xl lg:text-4xl font-extrabold text-text">Live TV</h1>
+                <p class="mt-2 text-sm text-text-secondary max-w-2xl">
+                    Direct-first live channels. Header-sensitive sources include an optional VPS fallback.
+                </p>
+            </div>
+            <div class="flex flex-col sm:flex-row gap-3">
+                <button onclick="saveSettings()" class="px-5 py-3 rounded-2xl border border-primary/30 bg-primary/10 text-primary font-bold hover:bg-primary hover:text-background transition-all inline-flex items-center justify-center gap-2">
+                    <i class="fa-solid fa-floppy-disk"></i>
+                    Save Settings
+                </button>
+                <button id="sync-button" onclick="startSync()" class="px-5 py-3 rounded-2xl bg-primary text-background font-bold hover:brightness-110 transition-all inline-flex items-center justify-center gap-2">
+                    <i id="sync-icon" class="fa-solid fa-rotate"></i>
+                    Sync Now
+                </button>
+            </div>
+        </div>
+    </section>
+
+    <section class="grid grid-cols-2 lg:grid-cols-6 gap-4">
+        <div class="glass-panel rounded-[2rem] p-5">
+            <p class="text-[10px] uppercase tracking-[0.18em] text-text-secondary font-bold">Status</p>
+            <p id="status-value" class="mt-2 text-lg font-extrabold text-text">Loading</p>
+        </div>
+        <div class="glass-panel rounded-[2rem] p-5">
+            <p class="text-[10px] uppercase tracking-[0.18em] text-text-secondary font-bold">Channels</p>
+            <p id="channel-count" class="mt-2 text-3xl font-extrabold text-text">0</p>
+        </div>
+        <div class="glass-panel rounded-[2rem] p-5">
+            <p class="text-[10px] uppercase tracking-[0.18em] text-text-secondary font-bold">Streams</p>
+            <p id="stream-count" class="mt-2 text-3xl font-extrabold text-text">0</p>
+        </div>
+        <div class="glass-panel rounded-[2rem] p-5">
+            <p class="text-[10px] uppercase tracking-[0.18em] text-text-secondary font-bold">Direct</p>
+            <p id="direct-count" class="mt-2 text-3xl font-extrabold text-emerald-300">0</p>
+        </div>
+        <div class="glass-panel rounded-[2rem] p-5">
+            <p class="text-[10px] uppercase tracking-[0.18em] text-text-secondary font-bold">Header-Aware</p>
+            <p id="header-count" class="mt-2 text-3xl font-extrabold text-amber-300">0</p>
+        </div>
+        <div class="glass-panel rounded-[2rem] p-5">
+            <p class="text-[10px] uppercase tracking-[0.18em] text-text-secondary font-bold">Last Sync</p>
+            <p id="last-sync" class="mt-2 text-sm font-bold text-text leading-snug">Never</p>
+        </div>
+    </section>
+
+    <section class="grid lg:grid-cols-3 gap-6">
+        <div class="glass-panel rounded-[2.5rem] p-6 lg:col-span-1">
+            <div class="flex items-center gap-3 mb-5">
+                <div class="w-11 h-11 rounded-2xl bg-primary/10 text-primary flex items-center justify-center">
+                    <i class="fa-solid fa-sliders"></i>
+                </div>
+                <div>
+                    <h2 class="font-bold text-text">Catalog Settings</h2>
+                    <p class="text-xs text-text-secondary">India-only v1 rollout</p>
+                </div>
+            </div>
+            <div class="space-y-5">
+                <label class="flex items-center justify-between gap-4">
+                    <span>
+                        <span class="block text-sm font-bold text-text">Enable Live TV</span>
+                        <span class="block text-xs text-text-secondary mt-1">Advertise the TV catalog in the manifest.</span>
+                    </span>
+                    <input id="setting-enabled" type="checkbox" class="w-5 h-5 accent-[var(--primary)]">
+                </label>
+                <div class="rounded-2xl border border-primary/15 bg-primary/5 p-4 text-xs text-text-secondary space-y-2">
+                    <p class="font-bold text-text">Unlimited India catalog</p>
+                    <p>All playable Indian channels are indexed. Hidden, blocklisted, closed, NSFW, replaced, and unplayable channels are excluded.</p>
+                </div>
+                <div class="rounded-2xl border border-white/5 bg-white/[0.03] p-4 text-xs text-text-secondary space-y-2">
+                    <p><span class="font-bold text-text">Country:</span> India (IN)</p>
+                    <p><span class="font-bold text-text">Refresh:</span> Every 6 hours</p>
+                    <p><span class="font-bold text-text">EPG:</span> Deferred</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="glass-panel rounded-[2.5rem] p-6 lg:col-span-2">
+            <div class="flex items-start justify-between gap-4">
+                <div>
+                    <h2 class="font-bold text-text">Sync Health</h2>
+                    <p class="text-xs text-text-secondary mt-1">The previous good snapshot stays active if a refresh fails.</p>
+                </div>
+                <span id="sync-badge" class="text-[10px] font-bold uppercase tracking-[0.18em] bg-white/10 text-text-secondary px-3 py-1 rounded-full">Unknown</span>
+            </div>
+            <div class="mt-6 grid sm:grid-cols-2 gap-4 text-sm">
+                <div class="rounded-2xl border border-white/5 bg-white/[0.03] p-4">
+                    <p class="text-[10px] uppercase tracking-widest text-text-secondary font-bold">Source Updated</p>
+                    <p id="source-modified" class="mt-2 font-bold text-text break-words">Unknown</p>
+                </div>
+                <div class="rounded-2xl border border-white/5 bg-white/[0.03] p-4">
+                    <p class="text-[10px] uppercase tracking-widest text-text-secondary font-bold">Hidden Channels</p>
+                    <p id="hidden-count" class="mt-2 font-bold text-text">0</p>
+                </div>
+                <div class="rounded-2xl border border-white/5 bg-white/[0.03] p-4">
+                    <p class="text-[10px] uppercase tracking-widest text-text-secondary font-bold">Eligible India Channels</p>
+                    <p id="source-channel-count" class="mt-2 font-bold text-text">0</p>
+                </div>
+                <div class="rounded-2xl border border-white/5 bg-white/[0.03] p-4">
+                    <p class="text-[10px] uppercase tracking-widest text-text-secondary font-bold">Playable India Channels</p>
+                    <p id="playable-channel-count" class="mt-2 font-bold text-text">0</p>
+                </div>
+            </div>
+            <div id="sync-error" class="hidden mt-4 rounded-2xl border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-200"></div>
+        </div>
+    </section>
+
+    <section class="glass-panel rounded-[2.5rem] overflow-hidden">
+        <div class="p-6 border-b border-white/5">
+            <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+                <div>
+                    <h2 class="text-lg font-bold text-text">Channels</h2>
+                    <p class="text-xs text-text-secondary mt-1">Hidden channels are excluded from Stremio immediately.</p>
+                </div>
+                <div class="flex flex-col sm:flex-row gap-3">
+                    <div class="relative">
+                        <i class="fa-solid fa-magnifying-glass absolute left-4 top-1/2 -translate-y-1/2 text-text-secondary"></i>
+                        <input id="channel-search" type="search" placeholder="Search channels"
+                            class="w-full sm:w-64 rounded-2xl border border-white/10 bg-black/10 pl-11 pr-4 py-3 text-sm text-text outline-none focus:border-primary">
+                    </div>
+                    <select id="visibility-filter" class="rounded-2xl border border-white/10 bg-[var(--bg)] px-4 py-3 text-sm text-text outline-none">
+                        <option value="visible">Visible</option>
+                        <option value="all">All</option>
+                        <option value="hidden">Hidden</option>
+                    </select>
+                </div>
+            </div>
+        </div>
+
+        <div id="channels-loading" class="p-10 text-center text-sm text-text-secondary">Loading channels...</div>
+        <div id="channels-empty" class="hidden p-10 text-center">
+            <i class="fa-solid fa-tower-broadcast text-4xl text-white/10 mb-3"></i>
+            <p class="text-sm text-text-secondary">No channels match this view.</p>
+        </div>
+        <div id="channels-mobile" class="md:hidden p-4 space-y-4"></div>
+        <div id="channels-table-wrap" class="hidden md:block overflow-x-auto">
+            <table class="w-full text-left">
+                <thead>
+                    <tr class="bg-white/5 text-[10px] uppercase tracking-[0.2em] font-bold text-text-secondary">
+                        <th class="py-5 px-6">Channel</th>
+                        <th class="py-5 px-6">Categories</th>
+                        <th class="py-5 px-6">Languages</th>
+                        <th class="py-5 px-6">Streams</th>
+                        <th class="py-5 px-6">Routing</th>
+                        <th class="py-5 px-6 text-right">Visibility</th>
+                    </tr>
+                </thead>
+                <tbody id="channels-table" class="divide-y divide-white/5"></tbody>
+            </table>
+        </div>
+        <div id="pagination" class="hidden p-5 border-t border-white/5 flex items-center justify-between gap-4">
+            <button id="prev-page" onclick="changePage(-1)" class="px-4 py-2 rounded-xl border border-white/10 text-sm font-bold disabled:opacity-30">Previous</button>
+            <span id="page-label" class="text-xs text-text-secondary">Page 1</span>
+            <button id="next-page" onclick="changePage(1)" class="px-4 py-2 rounded-xl border border-white/10 text-sm font-bold disabled:opacity-30">Next</button>
+        </div>
+    </section>
+</div>
+
+<script>
+let currentPage = 1;
+let totalPages = 0;
+let searchTimer = null;
+let statusTimer = null;
+
+function fmtDate(value) {
+    if (!value) return 'Never';
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? String(value) : date.toLocaleString();
+}
+
+function routingLabel(channel) {
+    const streams = Array.isArray(channel?.streams) ? channel.streams : [];
+    const headers = streams.filter(item => item?.requires_headers).length;
+    if (!headers) return '<span class="text-emerald-300">Direct</span>';
+    if (headers === streams.length) return '<span class="text-amber-300">Headers + fallback</span>';
+    return '<span class="text-sky-300">Mixed</span>';
+}
+
+function logoMarkup(channel) {
+    if (channel?.logo) {
+        return `<img src="${escapeHtml(channel.logo)}" alt="" class="w-12 h-12 rounded-xl object-contain bg-white p-1" loading="lazy">`;
+    }
+    return '<div class="w-12 h-12 rounded-xl bg-primary/10 text-primary flex items-center justify-center"><i class="fa-solid fa-tv"></i></div>';
+}
+
+function visibilityButton(channel) {
+    const hidden = Boolean(channel?.hidden);
+    return `<button onclick="toggleChannel('${escapeHtml(channel._id)}', ${hidden ? 'false' : 'true'})"
+        class="px-3 py-2 rounded-xl text-xs font-bold ${hidden ? 'bg-primary/10 text-primary' : 'bg-red-500/10 text-red-300'}">
+        ${hidden ? 'Show' : 'Hide'}
+    </button>`;
+}
+
+function mobileCard(channel) {
+    return `
+        <article class="glass-panel rounded-[2rem] p-5">
+            <div class="flex items-start gap-4">
+                ${logoMarkup(channel)}
+                <div class="min-w-0 flex-1">
+                    <h3 class="font-bold text-text truncate">${escapeHtml(channel?.name || channel?._id)}</h3>
+                    <p class="text-xs text-text-secondary mt-1 truncate">${escapeHtml((channel?.categories || []).join(', ') || 'Uncategorized')}</p>
+                </div>
+                ${visibilityButton(channel)}
+            </div>
+            <div class="mt-4 pt-4 border-t border-white/5 grid grid-cols-2 gap-3 text-xs">
+                <div><p class="text-text-secondary">Languages</p><p class="mt-1 font-bold text-text">${escapeHtml((channel?.languages || []).join(', ') || '-')}</p></div>
+                <div><p class="text-text-secondary">Streams</p><p class="mt-1 font-bold text-text">${Number(channel?.stream_count || 0)}</p></div>
+                <div class="col-span-2"><p class="text-text-secondary">Routing</p><p class="mt-1 font-bold">${routingLabel(channel)}</p></div>
+            </div>
+        </article>`;
+}
+
+function tableRow(channel) {
+    return `
+        <tr class="hover:bg-white/[0.02] transition-colors">
+            <td class="py-5 px-6 min-w-[260px]">
+                <div class="flex items-center gap-3">
+                    ${logoMarkup(channel)}
+                    <div class="min-w-0">
+                        <p class="font-bold text-text truncate max-w-[260px]">${escapeHtml(channel?.name || channel?._id)}</p>
+                        <p class="text-[10px] font-mono text-text-secondary mt-1">${escapeHtml(channel?._id || '')}</p>
+                    </div>
+                </div>
+            </td>
+            <td class="py-5 px-6 text-xs text-text-secondary max-w-[240px]">${escapeHtml((channel?.categories || []).join(', ') || '-')}</td>
+            <td class="py-5 px-6 text-xs text-text-secondary">${escapeHtml((channel?.languages || []).join(', ') || '-')}</td>
+            <td class="py-5 px-6 font-bold text-text">${Number(channel?.stream_count || 0)}</td>
+            <td class="py-5 px-6 text-xs font-bold">${routingLabel(channel)}</td>
+            <td class="py-5 px-6 text-right">${visibilityButton(channel)}</td>
+        </tr>`;
+}
+
+async function loadStatus() {
+    try {
+        const response = await fetch('/api/iptv/status', {cache: 'no-store'});
+        if (!response.ok) throw new Error('Unable to load IPTV status');
+        const data = await response.json();
+        const counts = data?.counts || {};
+        const settings = data?.settings || {};
+        const running = Boolean(data?.running);
+
+        document.getElementById('status-value').textContent = running ? 'Syncing' : String(data?.status || 'Unknown');
+        document.getElementById('channel-count').textContent = Number(counts?.visible_channels || 0).toLocaleString();
+        document.getElementById('stream-count').textContent = Number(counts?.selected_streams || 0).toLocaleString();
+        document.getElementById('direct-count').textContent = Number(counts?.direct_streams || 0).toLocaleString();
+        document.getElementById('header-count').textContent = Number(counts?.header_streams || 0).toLocaleString();
+        document.getElementById('hidden-count').textContent = Number(counts?.hidden_channels || 0).toLocaleString();
+        document.getElementById('source-channel-count').textContent = Number(counts?.source_country_channels || counts?.source_channels || 0).toLocaleString();
+        document.getElementById('playable-channel-count').textContent = Number(counts?.playable_country_channels || counts?.selected_channels || 0).toLocaleString();
+        document.getElementById('last-sync').textContent = fmtDate(data?.last_completed_at);
+        document.getElementById('source-modified').textContent = data?.source_last_modified || 'Unknown';
+        document.getElementById('setting-enabled').checked = Boolean(settings?.enabled);
+
+        const badge = document.getElementById('sync-badge');
+        badge.textContent = running ? 'Syncing' : String(data?.status || 'Unknown');
+        badge.className = `text-[10px] font-bold uppercase tracking-[0.18em] px-3 py-1 rounded-full ${
+            data?.status === 'error' ? 'bg-red-500/15 text-red-300' :
+            running ? 'bg-amber-500/15 text-amber-300' :
+            'bg-emerald-500/15 text-emerald-300'
+        }`;
+
+        const error = document.getElementById('sync-error');
+        if (data?.last_error) {
+            error.textContent = data.last_error;
+            error.classList.remove('hidden');
+        } else {
+            error.classList.add('hidden');
+        }
+
+        const syncButton = document.getElementById('sync-button');
+        syncButton.disabled = running;
+        document.getElementById('sync-icon').classList.toggle('animate-spin', running);
+    } catch (error) {
+        showToast(error.message, 'error', 'Live TV');
+    }
+}
+
+function hiddenFilterValue() {
+    const value = document.getElementById('visibility-filter').value;
+    if (value === 'hidden') return 'true';
+    if (value === 'visible') return 'false';
+    return '';
+}
+
+async function loadChannels(resetPage = false) {
+    if (resetPage) currentPage = 1;
+    const loading = document.getElementById('channels-loading');
+    const empty = document.getElementById('channels-empty');
+    const mobile = document.getElementById('channels-mobile');
+    const tableWrap = document.getElementById('channels-table-wrap');
+    const table = document.getElementById('channels-table');
+    loading.classList.remove('hidden');
+    empty.classList.add('hidden');
+
+    const params = new URLSearchParams({
+        page: String(currentPage),
+        page_size: '50',
+        search: document.getElementById('channel-search').value.trim(),
+    });
+    const hidden = hiddenFilterValue();
+    if (hidden) params.set('hidden', hidden);
+
+    try {
+        const response = await fetch(`/api/iptv/channels?${params}`, {cache: 'no-store'});
+        if (!response.ok) throw new Error('Unable to load IPTV channels');
+        const data = await response.json();
+        const channels = Array.isArray(data?.channels) ? data.channels : [];
+        totalPages = Number(data?.total_pages || 0);
+
+        mobile.innerHTML = channels.map(mobileCard).join('');
+        table.innerHTML = channels.map(tableRow).join('');
+        tableWrap.classList.toggle('hidden', channels.length === 0);
+        empty.classList.toggle('hidden', channels.length !== 0);
+        document.getElementById('pagination').classList.toggle('hidden', totalPages <= 1);
+        document.getElementById('page-label').textContent = `Page ${currentPage} of ${Math.max(1, totalPages)}`;
+        document.getElementById('prev-page').disabled = currentPage <= 1;
+        document.getElementById('next-page').disabled = currentPage >= totalPages;
+    } catch (error) {
+        showToast(error.message, 'error', 'Channels');
+    } finally {
+        loading.classList.add('hidden');
+    }
+}
+
+async function startSync() {
+    try {
+        const response = await fetch('/api/iptv/sync?force=true', {method: 'POST'});
+        const data = await response.json();
+        if (!response.ok) throw new Error(data?.detail || 'Unable to start sync');
+        showToast('IPTV synchronization started.', 'success', 'Live TV');
+        await loadStatus();
+    } catch (error) {
+        showToast(error.message, 'error', 'Live TV');
+    }
+}
+
+async function saveSettings() {
+    const payload = {
+        enabled: document.getElementById('setting-enabled').checked,
+    };
+    try {
+        const response = await fetch('/api/iptv/settings', {
+            method: 'PUT',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify(payload),
+        });
+        const data = await response.json();
+        if (!response.ok) throw new Error(data?.detail || 'Unable to save settings');
+        showToast('Settings saved.', 'success', 'Live TV');
+        await loadStatus();
+    } catch (error) {
+        showToast(error.message, 'error', 'Live TV');
+    }
+}
+
+async function toggleChannel(channelId, hidden) {
+    try {
+        const response = await fetch(`/api/iptv/channels/${encodeURIComponent(channelId)}`, {
+            method: 'PATCH',
+            headers: {'Content-Type': 'application/json'},
+            body: JSON.stringify({hidden}),
+        });
+        const data = await response.json();
+        if (!response.ok) throw new Error(data?.detail || 'Unable to update channel');
+        showToast(hidden ? 'Channel hidden from Stremio.' : 'Channel restored.', 'success', 'Live TV');
+        await Promise.all([loadChannels(), loadStatus()]);
+    } catch (error) {
+        showToast(error.message, 'error', 'Live TV');
+    }
+}
+
+function changePage(delta) {
+    const next = currentPage + delta;
+    if (next < 1 || next > totalPages) return;
+    currentPage = next;
+    loadChannels();
+}
+
+document.getElementById('visibility-filter').addEventListener('change', () => loadChannels(true));
+document.getElementById('channel-search').addEventListener('input', () => {
+    clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => loadChannels(true), 350);
+});
+
+Promise.all([loadStatus(), loadChannels(true)]);
+statusTimer = setInterval(loadStatus, 30000);
+window.addEventListener('beforeunload', () => clearInterval(statusTimer));
+</script>
+{% endblock %}

--- a/Backend/helper/iptv.py
+++ b/Backend/helper/iptv.py
@@ -1,0 +1,711 @@
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import re
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+
+import httpx
+from pymongo import ASCENDING, ReplaceOne
+
+from Backend.config import Telegram
+from Backend.logger import LOGGER
+
+
+IPTV_STATE_ID = "iptv_sync_state"
+IPTV_SETTINGS_ID = "iptv_settings"
+IPTV_CATALOG_ID = "iptv_india"
+IPTV_ID_PREFIX = "iptv:"
+IPTV_DATASETS = (
+    "channels",
+    "feeds",
+    "logos",
+    "streams",
+    "categories",
+    "languages",
+    "countries",
+    "blocklist",
+)
+
+_sync_lock = asyncio.Lock()
+_sync_task: Optional[asyncio.Task] = None
+
+
+def _utcnow() -> datetime:
+    return datetime.utcnow()
+
+
+def _api_url(name: str) -> str:
+    return f"{Telegram.IPTV_API_BASE_URL}/{name}.json"
+
+
+def _stream_id(stream: dict) -> str:
+    identity = "\n".join(
+        [
+            str(stream.get("url") or ""),
+            str(stream.get("referrer") or ""),
+            str(stream.get("user_agent") or ""),
+        ]
+    )
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:24]
+
+
+def _supported_stream_url(url: str) -> bool:
+    try:
+        parsed = urlparse(str(url or "").strip())
+        return parsed.scheme.lower() in {"http", "https"} and bool(parsed.netloc)
+    except Exception:
+        return False
+
+
+def channel_is_eligible(channel: dict, country_codes: set, blocked_ids: set) -> bool:
+    channel_id = str(channel.get("id") or "")
+    return bool(
+        channel_id
+        and str(channel.get("country") or "").upper() in country_codes
+        and not channel.get("is_nsfw")
+        and not channel.get("closed")
+        and not channel.get("replaced_by")
+        and channel_id not in blocked_ids
+    )
+
+
+def _quality_score(value: str) -> int:
+    text = str(value or "").lower()
+    if "2160" in text or "4k" in text:
+        return 2160
+    match = re.search(r"(\d{3,4})", text)
+    if match:
+        return int(match.group(1))
+    if "hd" in text:
+        return 720
+    if "sd" in text:
+        return 480
+    return 0
+
+
+def _stream_rank(stream: dict, feed: Optional[dict]) -> Tuple[int, int, int, int]:
+    url = str(stream.get("url") or "")
+    quality = stream.get("quality") or (feed or {}).get("format") or ""
+    no_headers = not stream.get("referrer") and not stream.get("user_agent")
+    is_https = url.lower().startswith("https://")
+    is_hls = ".m3u8" in url.lower()
+    return (
+        _quality_score(quality),
+        1 if no_headers else 0,
+        1 if is_https else 0,
+        1 if is_hls else 0,
+    )
+
+
+def _pick_logo(channel_id: str, stream_feeds: set, logos_by_channel: Dict[str, List[dict]]) -> str:
+    logos = logos_by_channel.get(channel_id) or []
+    if not logos:
+        return ""
+
+    def logo_score(logo: dict) -> tuple:
+        feed = logo.get("feed")
+        feed_match = 2 if feed and feed in stream_feeds else 1 if not feed else 0
+        area = int(logo.get("width") or 0) * int(logo.get("height") or 0)
+        return feed_match, area
+
+    selected = max(logos, key=logo_score)
+    return str(selected.get("url") or "")
+
+
+def _channel_description(channel: dict, feeds: List[dict], country_name: str) -> str:
+    parts = []
+    categories = channel.get("categories") or []
+    if categories:
+        parts.append(", ".join(str(item) for item in categories))
+    languages = []
+    for feed in feeds:
+        for language in feed.get("language_names") or []:
+            if language not in languages:
+                languages.append(language)
+    if languages:
+        parts.append("Languages: " + ", ".join(languages))
+    if country_name:
+        parts.append(country_name)
+    return " | ".join(parts) or "Live television channel"
+
+
+async def get_iptv_settings(db) -> dict:
+    state = await db.dbs["tracking"]["state"].find_one({"_id": IPTV_SETTINGS_ID}) or {}
+    enabled = state.get("enabled")
+    return {
+        "enabled": Telegram.IPTV_ENABLED if enabled is None else bool(enabled),
+        "country_codes": list(Telegram.IPTV_COUNTRY_CODES),
+        "channel_limit": 0,
+        "unlimited": True,
+        "auto_sync": bool(Telegram.IPTV_AUTO_SYNC),
+        "sync_interval_minutes": int(Telegram.IPTV_SYNC_INTERVAL_MINUTES),
+        "proxy_fallback_enabled": bool(Telegram.IPTV_PROXY_FALLBACK_ENABLED),
+        "catalog_id": IPTV_CATALOG_ID,
+    }
+
+
+async def update_iptv_settings(db, payload: dict) -> dict:
+    update = {"updated_at": _utcnow()}
+    if "enabled" in payload:
+        update["enabled"] = bool(payload.get("enabled"))
+    await db.dbs["tracking"]["state"].update_one(
+        {"_id": IPTV_SETTINGS_ID},
+        {"$set": update, "$unset": {"channel_limit": ""}},
+        upsert=True,
+    )
+    return await get_iptv_settings(db)
+
+
+async def get_iptv_sync_status(db) -> dict:
+    state = await db.dbs["tracking"]["state"].find_one({"_id": IPTV_STATE_ID}) or {}
+    settings = await get_iptv_settings(db)
+    total_channels = await db.dbs["tracking"]["iptv_channels"].count_documents({})
+    visible_channels = await db.dbs["tracking"]["iptv_channels"].count_documents({"hidden": {"$ne": True}})
+    state.pop("_id", None)
+    return {
+        "status": state.get("status", "never_synced"),
+        "running": bool(state.get("running", False)),
+        "last_started_at": state.get("last_started_at"),
+        "last_completed_at": state.get("last_completed_at"),
+        "last_error": state.get("last_error"),
+        "source_etag": state.get("source_etag"),
+        "source_last_modified": state.get("source_last_modified"),
+        "sync_id": state.get("sync_id"),
+        "counts": {
+            **(state.get("counts") or {}),
+            "total_channels": total_channels,
+            "visible_channels": visible_channels,
+            "hidden_channels": max(0, total_channels - visible_channels),
+        },
+        "settings": settings,
+    }
+
+
+async def _fetch_json(client: httpx.AsyncClient, dataset: str) -> list:
+    response = await client.get(_api_url(dataset))
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, list):
+        raise ValueError(f"Unexpected {dataset}.json response")
+    return data
+
+
+async def sync_iptv_data(db, force: bool = False) -> dict:
+    if _sync_lock.locked():
+        return {"started": False, "reason": "sync_already_running"}
+
+    async with _sync_lock:
+        settings = await get_iptv_settings(db)
+        if not settings["enabled"] and not force:
+            return {"started": False, "reason": "iptv_disabled"}
+
+        now = _utcnow()
+        state_collection = db.dbs["tracking"]["state"]
+        await state_collection.update_one(
+            {"_id": IPTV_SETTINGS_ID},
+            {"$unset": {"channel_limit": ""}},
+            upsert=True,
+        )
+        previous = await state_collection.find_one({"_id": IPTV_STATE_ID}) or {}
+        await state_collection.update_one(
+            {"_id": IPTV_STATE_ID},
+            {
+                "$set": {
+                    "status": "running",
+                    "running": True,
+                    "last_started_at": now,
+                    "last_error": None,
+                }
+            },
+            upsert=True,
+        )
+
+        timeout = httpx.Timeout(Telegram.IPTV_REQUEST_TIMEOUT_SEC)
+        headers = {
+            "User-Agent": "Telegram-Stremio-IPTV/1.0",
+            "Accept": "application/json",
+        }
+        if not force:
+            if previous.get("source_etag"):
+                headers["If-None-Match"] = str(previous["source_etag"])
+            if previous.get("source_last_modified"):
+                headers["If-Modified-Since"] = str(previous["source_last_modified"])
+
+        try:
+            async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+                stream_response = await client.get(_api_url("streams"), headers=headers)
+                if stream_response.status_code == 304:
+                    completed = _utcnow()
+                    await state_collection.update_one(
+                        {"_id": IPTV_STATE_ID},
+                        {
+                            "$set": {
+                                "status": "unchanged",
+                                "running": False,
+                                "last_completed_at": completed,
+                                "last_error": None,
+                            }
+                        },
+                        upsert=True,
+                    )
+                    return {"started": True, "status": "unchanged"}
+
+                stream_response.raise_for_status()
+                all_streams = stream_response.json()
+                if not isinstance(all_streams, list):
+                    raise ValueError("Unexpected streams.json response")
+
+                channels_raw = await _fetch_json(client, "channels")
+                blocklist_raw = await _fetch_json(client, "blocklist")
+                country_codes = set(settings["country_codes"])
+                blocked_ids = {
+                    str(item.get("channel"))
+                    for item in blocklist_raw
+                    if item.get("channel")
+                }
+
+                eligible_channels = {
+                    str(item["id"]): item
+                    for item in channels_raw
+                    if channel_is_eligible(item, country_codes, blocked_ids)
+                }
+                channels = dict(eligible_channels)
+                channel_ids = set(channels)
+
+                streams = [
+                    item
+                    for item in all_streams
+                    if str(item.get("channel") or "") in channel_ids
+                    and _supported_stream_url(item.get("url"))
+                ]
+                active_channel_ids = {str(item.get("channel")) for item in streams}
+                channels = {
+                    channel_id: item
+                    for channel_id, item in channels.items()
+                    if channel_id in active_channel_ids
+                }
+                channel_ids = set(channels)
+
+                feeds_raw = await _fetch_json(client, "feeds")
+                feeds = [
+                    item for item in feeds_raw
+                    if str(item.get("channel") or "") in channel_ids
+                ]
+                logos_raw = await _fetch_json(client, "logos")
+                logos = [
+                    item for item in logos_raw
+                    if str(item.get("channel") or "") in channel_ids
+                ]
+                categories_raw = await _fetch_json(client, "categories")
+                languages_raw = await _fetch_json(client, "languages")
+                countries_raw = await _fetch_json(client, "countries")
+
+            category_names = {
+                str(item.get("id")): str(item.get("name") or item.get("id") or "")
+                for item in categories_raw
+                if item.get("id")
+            }
+            language_names = {
+                str(item.get("code")): str(item.get("name") or item.get("code") or "")
+                for item in languages_raw
+                if item.get("code")
+            }
+            country_names = {
+                str(item.get("code")): {
+                    "name": str(item.get("name") or item.get("code") or ""),
+                    "flag": str(item.get("flag") or ""),
+                }
+                for item in countries_raw
+                if item.get("code")
+            }
+
+            feeds_by_key: Dict[tuple, dict] = {}
+            feeds_by_channel: Dict[str, List[dict]] = {}
+            for feed in feeds:
+                channel_id = str(feed.get("channel") or "")
+                feed_id = str(feed.get("id") or "")
+                enriched = dict(feed)
+                enriched["language_names"] = [
+                    language_names.get(str(code), str(code))
+                    for code in feed.get("languages") or []
+                ]
+                feeds_by_key[(channel_id, feed_id)] = enriched
+                feeds_by_channel.setdefault(channel_id, []).append(enriched)
+
+            logos_by_channel: Dict[str, List[dict]] = {}
+            for logo in logos:
+                logos_by_channel.setdefault(str(logo.get("channel") or ""), []).append(logo)
+
+            streams_by_channel: Dict[str, List[dict]] = {}
+            for stream in streams:
+                channel_id = str(stream.get("channel") or "")
+                feed_id = str(stream.get("feed") or "")
+                feed = feeds_by_key.get((channel_id, feed_id))
+                quality = stream.get("quality") or (feed or {}).get("format") or "Live"
+                request_headers = {}
+                if stream.get("referrer"):
+                    request_headers["Referer"] = str(stream["referrer"])
+                if stream.get("user_agent"):
+                    request_headers["User-Agent"] = str(stream["user_agent"])
+
+                item = {
+                    "id": _stream_id(stream),
+                    "url": str(stream.get("url")),
+                    "title": str(stream.get("title") or ""),
+                    "quality": str(quality),
+                    "feed": feed_id or None,
+                    "feed_name": (feed or {}).get("name") or feed_id or None,
+                    "is_main_feed": bool((feed or {}).get("is_main", False)),
+                    "languages": (feed or {}).get("language_names") or [],
+                    "format": (feed or {}).get("format"),
+                    "request_headers": request_headers,
+                    "requires_headers": bool(request_headers),
+                    "rank": _stream_rank(stream, feed),
+                }
+                streams_by_channel.setdefault(channel_id, []).append(item)
+
+            existing_hidden = {
+                str(item["_id"]): bool(item.get("hidden"))
+                async for item in db.dbs["tracking"]["iptv_channels"].find(
+                    {"hidden": True}, {"_id": 1, "hidden": 1}
+                )
+            }
+
+            sync_id = hashlib.sha256(
+                f"{now.isoformat()}:{stream_response.headers.get('etag', '')}".encode("utf-8")
+            ).hexdigest()[:16]
+            documents = []
+            for channel_id, channel in channels.items():
+                channel_streams = sorted(
+                    streams_by_channel.get(channel_id, []),
+                    key=lambda item: tuple(item.get("rank") or (0, 0, 0, 0)),
+                    reverse=True,
+                )[:5]
+                if not channel_streams:
+                    continue
+
+                channel_feeds = feeds_by_channel.get(channel_id, [])
+                stream_feed_ids = {
+                    str(item.get("feed"))
+                    for item in channel_streams
+                    if item.get("feed")
+                }
+                country = country_names.get(str(channel.get("country") or ""), {})
+                category_ids = [str(item) for item in channel.get("categories") or []]
+                category_values = [
+                    category_names.get(category_id, category_id)
+                    for category_id in category_ids
+                ]
+                language_values = []
+                for feed in channel_feeds:
+                    for language in feed.get("language_names") or []:
+                        if language not in language_values:
+                            language_values.append(language)
+
+                documents.append(
+                    {
+                        "_id": channel_id,
+                        "stremio_id": f"{IPTV_ID_PREFIX}{channel_id}",
+                        "name": str(channel.get("name") or channel_id),
+                        "alt_names": channel.get("alt_names") or [],
+                        "network": channel.get("network"),
+                        "country": str(channel.get("country") or ""),
+                        "country_name": country.get("name") or "",
+                        "country_flag": country.get("flag") or "",
+                        "categories": category_values,
+                        "category_ids": category_ids,
+                        "languages": language_values,
+                        "website": channel.get("website"),
+                        "logo": _pick_logo(channel_id, stream_feed_ids, logos_by_channel),
+                        "description": _channel_description(channel, channel_feeds, country.get("name") or ""),
+                        "hidden": existing_hidden.get(channel_id, False),
+                        "streams": channel_streams,
+                        "stream_count": len(channel_streams),
+                        "sync_id": sync_id,
+                        "updated_at": now,
+                    }
+                )
+
+            documents.sort(
+                key=lambda item: (
+                    max(
+                        [tuple(stream.get("rank") or (0, 0, 0, 0)) for stream in item.get("streams", [])]
+                        or [(0, 0, 0, 0)]
+                    ),
+                    item.get("stream_count", 0),
+                    item.get("name", "").lower(),
+                ),
+                reverse=True,
+            )
+            documents.sort(key=lambda item: item.get("name", "").lower())
+
+            collection = db.dbs["tracking"]["iptv_channels"]
+            if documents:
+                await collection.bulk_write(
+                    [ReplaceOne({"_id": item["_id"]}, item, upsert=True) for item in documents],
+                    ordered=False,
+                )
+            await collection.delete_many({"sync_id": {"$ne": sync_id}})
+            await collection.create_index([("name", ASCENDING)])
+            await collection.create_index([("hidden", ASCENDING), ("name", ASCENDING)])
+            await collection.create_index("streams.id")
+
+            direct_streams = sum(
+                1
+                for item in documents
+                for stream in item.get("streams", [])
+                if not stream.get("requires_headers")
+            )
+            header_streams = sum(
+                1
+                for item in documents
+                for stream in item.get("streams", [])
+                if stream.get("requires_headers")
+            )
+            completed = _utcnow()
+            counts = {
+                "source_country_channels": len(eligible_channels),
+                "playable_country_channels": len(channels),
+                "source_channels": len(eligible_channels),
+                "source_streams": len(streams),
+                "selected_channels": len(documents),
+                "selected_streams": direct_streams + header_streams,
+                "direct_streams": direct_streams,
+                "header_streams": header_streams,
+                "blocked_channels": len(blocked_ids),
+                "channel_limit": 0,
+                "unlimited": True,
+            }
+            await state_collection.update_one(
+                {"_id": IPTV_STATE_ID},
+                {
+                    "$set": {
+                        "status": "ok",
+                        "running": False,
+                        "last_completed_at": completed,
+                        "last_error": None,
+                        "source_etag": stream_response.headers.get("etag"),
+                        "source_last_modified": stream_response.headers.get("last-modified"),
+                        "sync_id": sync_id,
+                        "counts": counts,
+                    }
+                },
+                upsert=True,
+            )
+            LOGGER.info(
+                "IPTV sync complete: %s channels, %s streams",
+                counts["selected_channels"],
+                counts["selected_streams"],
+            )
+            return {"started": True, "status": "ok", "counts": counts}
+        except Exception as exc:
+            LOGGER.exception("IPTV sync failed")
+            await state_collection.update_one(
+                {"_id": IPTV_STATE_ID},
+                {
+                    "$set": {
+                        "status": "error",
+                        "running": False,
+                        "last_completed_at": _utcnow(),
+                        "last_error": str(exc)[:500],
+                    }
+                },
+                upsert=True,
+            )
+            return {"started": True, "status": "error", "error": str(exc)}
+
+
+async def start_iptv_sync_background(db, force: bool = False, delay_seconds: int = 0) -> dict:
+    global _sync_task
+    if _sync_task and not _sync_task.done():
+        return {"started": False, "reason": "sync_already_running"}
+
+    async def runner():
+        if delay_seconds > 0:
+            await asyncio.sleep(delay_seconds)
+        await sync_iptv_data(db, force=force)
+
+    _sync_task = asyncio.create_task(runner())
+    return {"started": True}
+
+
+async def start_iptv_interval_loop(db) -> None:
+    if not Telegram.IPTV_AUTO_SYNC:
+        return
+    interval = max(30, int(Telegram.IPTV_SYNC_INTERVAL_MINUTES)) * 60
+    while True:
+        try:
+            await asyncio.sleep(interval)
+            settings = await get_iptv_settings(db)
+            if settings.get("enabled"):
+                await sync_iptv_data(db, force=False)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            LOGGER.exception("IPTV interval sync failed")
+
+
+async def list_iptv_channels(
+    db,
+    *,
+    search: str = "",
+    category: str = "",
+    hidden: Optional[bool] = None,
+    page: int = 1,
+    page_size: int = 50,
+) -> dict:
+    query = {}
+    if hidden is not None:
+        query["hidden"] = bool(hidden)
+    search = (search or "").strip()
+    category = (category or "").strip()
+    if category:
+        query["categories"] = category
+    if search:
+        query["$or"] = [
+            {"name": {"$regex": re.escape(search), "$options": "i"}},
+            {"alt_names": {"$regex": re.escape(search), "$options": "i"}},
+            {"languages": {"$regex": re.escape(search), "$options": "i"}},
+            {"categories": {"$regex": re.escape(search), "$options": "i"}},
+        ]
+    page = max(1, int(page))
+    page_size = max(1, min(100, int(page_size)))
+    total = await db.dbs["tracking"]["iptv_channels"].count_documents(query)
+    items = await (
+        db.dbs["tracking"]["iptv_channels"]
+        .find(query)
+        .sort("name", ASCENDING)
+        .skip((page - 1) * page_size)
+        .limit(page_size)
+        .to_list(None)
+    )
+    for item in items:
+        item["_id"] = str(item["_id"])
+    return {
+        "channels": items,
+        "total_count": total,
+        "current_page": page,
+        "total_pages": (total + page_size - 1) // page_size if total else 0,
+    }
+
+
+async def get_iptv_channel(db, channel_id: str, include_hidden: bool = False) -> Optional[dict]:
+    query = {"_id": channel_id}
+    if not include_hidden:
+        query["hidden"] = {"$ne": True}
+    return await db.dbs["tracking"]["iptv_channels"].find_one(query)
+
+
+async def get_iptv_channel_by_stream(db, stream_id: str) -> Optional[dict]:
+    return await db.dbs["tracking"]["iptv_channels"].find_one(
+        {"streams.id": stream_id, "hidden": {"$ne": True}}
+    )
+
+
+async def set_iptv_channel_hidden(db, channel_id: str, hidden: bool) -> bool:
+    result = await db.dbs["tracking"]["iptv_channels"].update_one(
+        {"_id": channel_id},
+        {"$set": {"hidden": bool(hidden), "updated_at": _utcnow()}},
+    )
+    return result.matched_count > 0
+
+
+def iptv_meta(channel: dict) -> dict:
+    return {
+        "id": channel.get("stremio_id") or f"{IPTV_ID_PREFIX}{channel.get('_id')}",
+        "type": "tv",
+        "name": channel.get("name") or str(channel.get("_id")),
+        "description": channel.get("description") or "Live television channel",
+        "poster": channel.get("logo") or "",
+        "logo": channel.get("logo") or "",
+        "background": channel.get("logo") or "",
+        "genres": channel.get("categories") or [],
+        "country": channel.get("country_name") or channel.get("country") or "",
+        "language": ", ".join(channel.get("languages") or []),
+        "website": channel.get("website") or "",
+    }
+
+
+def _proxy_secret() -> bytes:
+    configured = (
+        Telegram.IPTV_PROXY_SECRET
+        or Telegram.BOT_TOKEN
+        or Telegram.DEFAULT_ADDON_TOKEN
+        or "telegram-stremio-iptv"
+    )
+    return configured.encode("utf-8")
+
+
+def sign_proxy_target(stream_id: str, url: str) -> str:
+    payload = json.dumps(
+        {"s": str(stream_id), "u": str(url)},
+        separators=(",", ":"),
+    ).encode("utf-8")
+    encoded = base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+    signature = hmac.new(_proxy_secret(), encoded.encode("ascii"), hashlib.sha256).hexdigest()[:32]
+    return f"{encoded}.{signature}"
+
+
+def verify_proxy_target(value: str) -> dict:
+    try:
+        encoded, signature = value.rsplit(".", 1)
+        expected = hmac.new(_proxy_secret(), encoded.encode("ascii"), hashlib.sha256).hexdigest()[:32]
+        if not hmac.compare_digest(signature, expected):
+            raise ValueError("invalid signature")
+        padding = "=" * ((4 - len(encoded) % 4) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(encoded + padding).decode("utf-8"))
+        if not payload.get("s") or not _supported_stream_url(payload.get("u")):
+            raise ValueError("invalid payload")
+        return payload
+    except Exception as exc:
+        raise ValueError("Invalid IPTV proxy target") from exc
+
+
+def build_iptv_streams(channel: dict, token: str) -> List[dict]:
+    streams = []
+    for index, source in enumerate(channel.get("streams") or [], start=1):
+        url = str(source.get("url") or "")
+        if not _supported_stream_url(url):
+            continue
+        quality = str(source.get("quality") or source.get("format") or "Live")
+        feed_name = source.get("feed_name") or source.get("title") or ""
+        languages = ", ".join(source.get("languages") or [])
+        details = [channel.get("name") or "Live TV", quality]
+        if feed_name:
+            details.append(str(feed_name))
+        if languages:
+            details.append(languages)
+
+        behavior_hints = {
+            "notWebReady": True,
+            "bingeGroup": f"telegram-stremio-iptv-{channel.get('_id')}",
+        }
+        request_headers = source.get("request_headers") or {}
+        if request_headers:
+            behavior_hints["proxyHeaders"] = {"request": request_headers}
+
+        direct = {
+            "name": f"Live TV {quality}",
+            "title": "\n".join(details),
+            "url": url,
+            "behaviorHints": behavior_hints,
+        }
+        streams.append(direct)
+
+        if request_headers and Telegram.IPTV_PROXY_FALLBACK_ENABLED:
+            streams.append(
+                {
+                    "name": f"Live TV {quality} (VPS fallback)",
+                    "title": "\n".join(details + ["Uses VPS bandwidth"]),
+                    "url": f"{Telegram.BASE_URL}/iptv/{token}/stream/{source.get('id')}",
+                    "behaviorHints": {
+                        "notWebReady": True,
+                        "bingeGroup": f"telegram-stremio-iptv-{channel.get('_id')}",
+                    },
+                }
+            )
+    return streams

--- a/sample_config.env
+++ b/sample_config.env
@@ -9,6 +9,21 @@ HIDE_CATALOG="false"
 PARALLEL="1"
 PRE_FETCH="1"
 
+# IPTV LIVE TV (iptv-org)
+# India-only v1. When enabled, all playable Indian channels are indexed.
+# Set IPTV_ENABLED="true" to advertise and synchronize the Live TV catalog.
+IPTV_ENABLED="false"
+IPTV_COUNTRY_CODES="IN"
+IPTV_PAGE_SIZE="50"
+IPTV_AUTO_SYNC="true"
+IPTV_SYNC_INTERVAL_MINUTES="360"
+IPTV_SYNC_START_DELAY_SECONDS="30"
+IPTV_REQUEST_TIMEOUT_SEC="45"
+IPTV_PROXY_TIMEOUT_SEC="30"
+IPTV_PROXY_FALLBACK_ENABLED="true"
+IPTV_PROXY_SECRET=""
+IPTV_API_BASE_URL="https://iptv-org.github.io/api"
+
 # STORAGE
 AUTH_CHANNEL=""
 DATABASE=""

--- a/tests/test_iptv.py
+++ b/tests/test_iptv.py
@@ -1,0 +1,409 @@
+import os
+import unittest
+from unittest.mock import AsyncMock, patch
+
+os.environ.setdefault(
+    "DATABASE",
+    "mongodb://localhost:27017/iptv_tracking,mongodb://localhost:27017/iptv_storage",
+)
+
+from Backend.fastapi.routes import iptv_routes, stremio_routes
+from Backend.helper.iptv import (
+    IPTV_CATALOG_ID,
+    build_iptv_streams,
+    channel_is_eligible,
+    get_iptv_settings,
+    iptv_meta,
+    sign_proxy_target,
+    sync_iptv_data,
+    update_iptv_settings,
+    verify_proxy_target,
+)
+
+
+class IptvHelperTests(unittest.TestCase):
+    def test_channel_filter_rejects_wrong_country_blocked_and_unsafe_channels(self):
+        base = {
+            "id": "Test.in",
+            "country": "IN",
+            "is_nsfw": False,
+            "closed": None,
+            "replaced_by": None,
+        }
+        self.assertTrue(channel_is_eligible(base, {"IN"}, set()))
+        self.assertFalse(channel_is_eligible({**base, "country": "US"}, {"IN"}, set()))
+        self.assertFalse(channel_is_eligible({**base, "is_nsfw": True}, {"IN"}, set()))
+        self.assertFalse(channel_is_eligible({**base, "closed": "2025-01-01"}, {"IN"}, set()))
+        self.assertFalse(channel_is_eligible({**base, "replaced_by": "Other.in"}, {"IN"}, set()))
+        self.assertFalse(channel_is_eligible(base, {"IN"}, {"Test.in"}))
+
+    def test_direct_and_header_streams_are_returned_in_direct_first_order(self):
+        channel = {
+            "_id": "News.in",
+            "name": "News",
+            "streams": [
+                {
+                    "id": "direct",
+                    "url": "https://example.test/live.m3u8",
+                    "quality": "1080p",
+                    "request_headers": {},
+                },
+                {
+                    "id": "headers",
+                    "url": "https://example.test/secure.m3u8",
+                    "quality": "720p",
+                    "request_headers": {
+                        "Referer": "https://example.test/",
+                        "User-Agent": "Test Agent",
+                    },
+                },
+            ],
+        }
+        with (
+            patch.object(stremio_routes.Telegram, "BASE_URL", "https://addon.test"),
+            patch.object(stremio_routes.Telegram, "IPTV_PROXY_FALLBACK_ENABLED", True),
+            patch("Backend.helper.iptv.Telegram.BASE_URL", "https://addon.test"),
+            patch("Backend.helper.iptv.Telegram.IPTV_PROXY_FALLBACK_ENABLED", True),
+        ):
+            streams = build_iptv_streams(channel, "token123")
+
+        self.assertEqual(len(streams), 3)
+        self.assertEqual(streams[0]["url"], "https://example.test/live.m3u8")
+        self.assertEqual(streams[1]["url"], "https://example.test/secure.m3u8")
+        self.assertEqual(
+            streams[1]["behaviorHints"]["proxyHeaders"]["request"]["Referer"],
+            "https://example.test/",
+        )
+        self.assertEqual(
+            streams[2]["url"],
+            "https://addon.test/iptv/token123/stream/headers",
+        )
+        self.assertIn("Uses VPS bandwidth", streams[2]["title"])
+
+    def test_signed_proxy_target_round_trip_and_tamper_rejection(self):
+        with patch("Backend.helper.iptv.Telegram.IPTV_PROXY_SECRET", "test-secret"):
+            signed = sign_proxy_target("stream1", "https://example.test/segment.ts")
+            payload = verify_proxy_target(signed)
+            self.assertEqual(payload["s"], "stream1")
+            self.assertEqual(payload["u"], "https://example.test/segment.ts")
+            with self.assertRaises(ValueError):
+                verify_proxy_target(signed[:-1] + ("0" if signed[-1] != "0" else "1"))
+
+    def test_hls_rewriter_proxies_relative_segments_and_key_urls(self):
+        manifest = (
+            "#EXTM3U\n"
+            '#EXT-X-KEY:METHOD=AES-128,URI="key.bin"\n'
+            "#EXTINF:5,\n"
+            "segments/one.ts\n"
+        )
+        with (
+            patch.object(iptv_routes.Telegram, "BASE_URL", "https://addon.test"),
+            patch("Backend.helper.iptv.Telegram.IPTV_PROXY_SECRET", "test-secret"),
+        ):
+            result = iptv_routes._rewrite_hls_manifest(
+                manifest,
+                "https://origin.test/live/master.m3u8",
+                "token123",
+                "stream1",
+            )
+
+        self.assertIn("https://addon.test/iptv/token123/fetch/", result)
+        self.assertNotIn('URI="key.bin"', result)
+        self.assertNotIn("\nsegments/one.ts\n", result)
+
+    def test_meta_uses_tv_type_and_stable_iptv_id(self):
+        meta = iptv_meta(
+            {
+                "_id": "News.in",
+                "name": "News",
+                "logo": "https://example.test/logo.png",
+                "categories": ["News"],
+                "languages": ["Hindi"],
+                "country_name": "India",
+            }
+        )
+        self.assertEqual(meta["id"], "iptv:News.in")
+        self.assertEqual(meta["type"], "tv")
+        self.assertEqual(meta["genres"], ["News"])
+
+
+class _AsyncCursor:
+    def __init__(self, items):
+        self.items = list(items)
+
+    def __aiter__(self):
+        self.index = 0
+        return self
+
+    async def __anext__(self):
+        if self.index >= len(self.items):
+            raise StopAsyncIteration
+        item = self.items[self.index]
+        self.index += 1
+        return item
+
+
+class _StateCollection:
+    def __init__(self, initial=None):
+        self.docs = dict(initial or {})
+        self.last_update = None
+
+    async def find_one(self, query):
+        return self.docs.get(query.get("_id"))
+
+    async def update_one(self, query, update, upsert=False):
+        self.last_update = update
+        doc = dict(self.docs.get(query.get("_id")) or {"_id": query.get("_id")})
+        doc.update(update.get("$set") or {})
+        for key in update.get("$unset") or {}:
+            doc.pop(key, None)
+        self.docs[query.get("_id")] = doc
+
+
+class _IptvCollection:
+    def __init__(self):
+        self.docs = {}
+        self.bulk_count = 0
+
+    def find(self, query=None, projection=None):
+        hidden_docs = [doc for doc in self.docs.values() if doc.get("hidden")]
+        return _AsyncCursor(hidden_docs)
+
+    async def bulk_write(self, operations, ordered=False):
+        self.bulk_count = len(operations)
+        for operation in operations:
+            self.docs[operation._filter["_id"]] = operation._doc
+
+    async def delete_many(self, query):
+        sync_id = (query.get("sync_id") or {}).get("$ne")
+        if sync_id:
+            self.docs = {
+                key: value
+                for key, value in self.docs.items()
+                if value.get("sync_id") == sync_id
+            }
+
+    async def create_index(self, *args, **kwargs):
+        return None
+
+    async def count_documents(self, query):
+        if query.get("hidden", {}).get("$ne") is True:
+            return len([doc for doc in self.docs.values() if not doc.get("hidden")])
+        return len(self.docs)
+
+
+class _IptvDb:
+    def __init__(self, state_initial=None):
+        self.state = _StateCollection(state_initial)
+        self.iptv_channels = _IptvCollection()
+        self.dbs = {
+            "tracking": {
+                "state": self.state,
+                "iptv_channels": self.iptv_channels,
+            }
+        }
+
+
+class _StreamsResponse:
+    status_code = 200
+    headers = {"etag": "test-etag", "last-modified": "today"}
+
+    def __init__(self, streams):
+        self.streams = streams
+
+    def json(self):
+        return self.streams
+
+    def raise_for_status(self):
+        return None
+
+
+class _HttpClient:
+    def __init__(self, streams):
+        self.streams = streams
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def get(self, url, headers=None):
+        return _StreamsResponse(self.streams)
+
+
+class IptvUnlimitedTests(unittest.IsolatedAsyncioTestCase):
+    async def test_settings_ignore_and_unset_legacy_channel_limit(self):
+        db = _IptvDb({"iptv_settings": {"_id": "iptv_settings", "enabled": True, "channel_limit": 100}})
+
+        settings = await get_iptv_settings(db)
+        self.assertEqual(settings["channel_limit"], 0)
+        self.assertTrue(settings["unlimited"])
+
+        updated = await update_iptv_settings(db, {"enabled": True, "channel_limit": 100})
+        self.assertEqual(updated["channel_limit"], 0)
+        self.assertIn("channel_limit", db.state.last_update.get("$unset", {}))
+        self.assertNotIn("channel_limit", db.state.docs["iptv_settings"])
+
+    async def test_sync_keeps_all_playable_indian_channels_above_old_pilot_cap(self):
+        channel_count = 125
+        channels = [
+            {
+                "id": f"Channel{i}.in",
+                "name": f"Channel {i}",
+                "country": "IN",
+                "categories": ["news"],
+                "is_nsfw": False,
+                "closed": None,
+                "replaced_by": None,
+            }
+            for i in range(channel_count)
+        ]
+        streams = [
+            {
+                "channel": f"Channel{i}.in",
+                "feed": None,
+                "title": "",
+                "url": f"https://example.test/{i}.m3u8",
+                "quality": "720p",
+            }
+            for i in range(channel_count)
+        ]
+
+        async def fake_fetch_json(client, dataset):
+            return {
+                "channels": channels,
+                "blocklist": [],
+                "feeds": [],
+                "logos": [],
+                "categories": [{"id": "news", "name": "News"}],
+                "languages": [],
+                "countries": [{"code": "IN", "name": "India", "flag": "IN"}],
+            }[dataset]
+
+        db = _IptvDb({"iptv_settings": {"_id": "iptv_settings", "enabled": True, "channel_limit": 100}})
+        with (
+            patch("Backend.helper.iptv._fetch_json", fake_fetch_json),
+            patch("Backend.helper.iptv.httpx.AsyncClient", lambda *args, **kwargs: _HttpClient(streams)),
+        ):
+            result = await sync_iptv_data(db, force=True)
+
+        self.assertEqual(result["counts"]["selected_channels"], channel_count)
+        self.assertEqual(result["counts"]["source_country_channels"], channel_count)
+        self.assertEqual(result["counts"]["playable_country_channels"], channel_count)
+        self.assertEqual(db.iptv_channels.bulk_count, channel_count)
+        self.assertNotIn("channel_limit", db.state.docs["iptv_settings"])
+
+
+class _DistinctCollection:
+    async def distinct(self, field, query):
+        return ["News", "Entertainment"]
+
+
+class _TrackingDB:
+    def __getitem__(self, name):
+        return _DistinctCollection()
+
+
+class _ManifestDB:
+    dbs = {"tracking": _TrackingDB()}
+
+    async def get_custom_catalogs(self, visible_only=False):
+        return []
+
+
+class IptvStremioRouteTests(unittest.IsolatedAsyncioTestCase):
+    async def test_manifest_advertises_tv_catalog_and_prefix(self):
+        with (
+            patch.object(stremio_routes, "db", _ManifestDB()),
+            patch.object(stremio_routes.Telegram, "HIDE_CATALOG", False),
+            patch.object(
+                stremio_routes,
+                "get_iptv_settings",
+                AsyncMock(return_value={"enabled": True}),
+            ),
+        ):
+            manifest = await stremio_routes.get_manifest(
+                "token123",
+                token_data={},
+            )
+
+        self.assertIn("tv", manifest["types"])
+        self.assertIn("iptv:", manifest["idPrefixes"])
+        live_catalog = [
+            item
+            for item in manifest["catalogs"]
+            if item["id"] == IPTV_CATALOG_ID
+        ]
+        self.assertEqual(len(live_catalog), 1)
+        self.assertEqual(live_catalog[0]["type"], "tv")
+
+    async def test_tv_catalog_returns_iptv_metas(self):
+        channel = {
+            "_id": "News.in",
+            "stremio_id": "iptv:News.in",
+            "name": "News",
+            "categories": ["News"],
+            "languages": ["Hindi"],
+        }
+        with (
+            patch.object(stremio_routes.Telegram, "HIDE_CATALOG", False),
+            patch.object(
+                stremio_routes,
+                "get_iptv_settings",
+                AsyncMock(return_value={"enabled": True}),
+            ),
+            patch.object(
+                stremio_routes,
+                "list_iptv_channels",
+                AsyncMock(return_value={"channels": [channel]}),
+            ),
+        ):
+            result = await stremio_routes.get_catalog(
+                "token123",
+                "tv",
+                IPTV_CATALOG_ID,
+                token_data={},
+            )
+
+        self.assertEqual(result["metas"][0]["id"], "iptv:News.in")
+        self.assertEqual(result["metas"][0]["type"], "tv")
+
+    async def test_tv_stream_route_returns_direct_url(self):
+        channel = {
+            "_id": "News.in",
+            "name": "News",
+            "streams": [
+                {
+                    "id": "direct",
+                    "url": "https://example.test/live.m3u8",
+                    "quality": "720p",
+                    "request_headers": {},
+                }
+            ],
+        }
+        with (
+            patch.object(
+                stremio_routes,
+                "get_iptv_settings",
+                AsyncMock(return_value={"enabled": True}),
+            ),
+            patch.object(
+                stremio_routes,
+                "get_iptv_channel",
+                AsyncMock(return_value=channel),
+            ),
+        ):
+            result = await stremio_routes.get_streams(
+                "token123",
+                "tv",
+                "iptv:News.in",
+                token_data={},
+            )
+
+        self.assertEqual(result["streams"][0]["url"], "https://example.test/live.m3u8")
+        self.assertTrue(result["streams"][0]["behaviorHints"]["notWebReady"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds an opt-in Live TV module to the existing addon using the public [iptv-org API](https://github.com/iptv-org/api) and [database](https://github.com/iptv-org/database).

The first version is India-only and indexes every playable Indian channel that is not NSFW, closed, replaced, or blocklisted. EPG is intentionally out of scope.

## What changed

- adds Stremio `tv` support with a `Live TV - India` catalog
- syncs channel, stream, feed, logo, category, language, country, and blocklist data
- stores multiple ranked stream candidates per channel
- uses direct upstream URLs first to avoid VPS bandwidth
- uses Stremio `proxyHeaders` for streams requiring a Referer/User-Agent
- provides a signed local HLS proxy fallback only when header-sensitive playback needs it
- adds a protected `/live-tv` admin page for status, manual sync, search, pagination, and hide/show controls
- refreshes the snapshot periodically while preserving the last good snapshot on failures
- keeps the feature disabled by default; set `IPTV_ENABLED="true"` to enable it

## Safety

- blocklisted and unsupported streams are excluded
- the local proxy accepts only signed URLs belonging to stored IPTV streams
- localhost/private literal IP targets are rejected
- existing movie and series catalog/stream behavior is unchanged

## Tests

- `python -m compileall Backend tests`
- `python -m unittest discover -v`
- 10 IPTV tests pass, covering filtering, direct/header streams, signed proxy targets, HLS rewriting, manifest/catalog/meta/stream responses, and unlimited channel synchronization