### PR TITLE
Improve metadata match confidence

### DIFF
--- a/Backend/helper/metadata.py
+++ b/Backend/helper/metadata.py
@@ -3,12 +3,20 @@ import traceback
 import PTN
 import re
 from re import compile, IGNORECASE
-from Backend.helper.imdb import get_detail, get_season, search_title
+from Backend.helper.imdb import get_detail, get_season, search_title, search_titles
 from themoviedb import aioTMDb
 from Backend.config import Telegram
 import Backend
 from Backend.logger import LOGGER
 from Backend.helper.encrypt import encode_string
+from Backend.helper.metadata_matcher import (
+    MatchCandidate,
+    MatchIntent,
+    build_title_variants,
+    choose_best_candidate,
+    decision_metadata,
+    normalize_title,
+)
 
 # ----------------- Configuration -----------------
 DELAY = 0
@@ -19,9 +27,11 @@ IMDB_CACHE: dict = {}
 TMDB_SEARCH_CACHE: dict = {}
 TMDB_DETAILS_CACHE: dict = {}
 EPISODE_CACHE: dict = {}
+MATCH_FAILURE_CACHE: dict = {}
 
-# Concurrency semaphore for external API calls
-API_SEMAPHORE = asyncio.Semaphore(12)
+# Concurrency semaphore for external API calls. Keep this conservative; bursts
+# of forwarded episodes can otherwise cause TMDb connection resets.
+API_SEMAPHORE = asyncio.Semaphore(4)
 
 # ----------------- Helpers -----------------
 def format_tmdb_image(path: str, size="w500") -> str:
@@ -69,6 +79,46 @@ def extract_default_id(url: str) -> str | None:
 
     return None
 
+
+def has_combined_marker(*values) -> bool:
+    for value in values:
+        if not value:
+            continue
+        if isinstance(value, dict):
+            parts = value.values()
+        elif isinstance(value, list):
+            parts = value
+        else:
+            parts = [value]
+        if any("combined" in str(item).lower() for item in parts):
+            return True
+    return False
+
+
+def infer_resolution_from_filename(filename: str, parsed: dict) -> str:
+    text = f"{filename} {parsed.get('quality', '')}".lower()
+
+    # Strong signals first
+    if any(tag in text for tag in ["2160", "4k", "uhd"]):
+        return "2160p"
+    if any(tag in text for tag in ["1080", "fhd"]):
+        return "1080p"
+    if "720" in text:
+        return "720p"
+    if "480" in text:
+        return "480p"
+    if "360" in text:
+        return "360p"
+
+    # If source/quality exists but no explicit resolution, keep it indexable
+    if any(tag in text for tag in [
+        "hdrip", "webrip", "web-dl", "hdtv", "dvdrip", "brrip", "bluray", "cam", "hdts", "hdtc"
+    ]):
+        return "480p"
+
+    return "SD"
+
+
 async def safe_imdb_search(title: str, type_: str) -> str | None:
     key = f"imdb::{type_}::{title}"
     if key in IMDB_CACHE:
@@ -98,58 +148,340 @@ async def safe_tmdb_search(title: str, type_: str, year=None):
         return res
     except Exception as e:
         LOGGER.error(f"TMDb search failed for '{title}' [{type_}]: {e}")
-        TMDB_SEARCH_CACHE[key] = None
         return None
+
+
+def _cache_key(channel, msg_id) -> str:
+    return f"{channel}:{msg_id}"
+
+
+def set_match_failure(channel, msg_id, details: dict) -> None:
+    MATCH_FAILURE_CACHE[_cache_key(channel, msg_id)] = details
+
+
+def pop_match_failure(channel, msg_id) -> dict:
+    return MATCH_FAILURE_CACHE.pop(_cache_key(channel, msg_id), {})
+
+
+def _safe_year(value) -> int | None:
+    try:
+        value = int(value)
+        return value if 1800 <= value <= 2200 else None
+    except Exception:
+        return None
+
+
+def _tmdb_year(item, attr: str) -> int | None:
+    value = getattr(item, attr, None)
+    return _safe_year(getattr(value, "year", None)) if value else None
+
+
+def _imdb_candidate(result: dict | None, media_type: str) -> MatchCandidate | None:
+    if not result or not result.get("id"):
+        return None
+    return MatchCandidate(
+        source="imdb",
+        title=result.get("title") or "",
+        year=_safe_year(result.get("year")),
+        media_type=media_type,
+        imdb_id=result.get("id"),
+        tmdb_id=result.get("moviedb_id"),
+        popularity=0.0,
+        raw=result,
+    )
+
+
+def _dedupe_candidates(candidates: list[MatchCandidate]) -> list[MatchCandidate]:
+    out: list[MatchCandidate] = []
+    seen: set[tuple[str, str]] = set()
+    for candidate in candidates:
+        if candidate.imdb_id:
+            key = ("imdb", str(candidate.imdb_id))
+        elif candidate.tmdb_id:
+            key = ("tmdb", str(candidate.tmdb_id))
+        else:
+            key = (candidate.media_type, f"{normalize_title(candidate.title)}::{candidate.year}")
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(candidate)
+    return out
+
+
+async def _database_candidates(variants: list[str], media_type: str, year=None, limit: int = 8) -> list[MatchCandidate]:
+    candidates: list[MatchCandidate] = []
+    try:
+        if not getattr(Backend.db, "dbs", None):
+            return []
+        collection = "movie" if media_type == "movie" else "tv"
+        for db_key in sorted(k for k in Backend.db.dbs if k.startswith("storage_")):
+            db = Backend.db.dbs[db_key]
+            for variant in variants:
+                if not variant:
+                    continue
+                query = {"title": {"$regex": f"^{re.escape(variant)}$", "$options": "i"}}
+                if year:
+                    query["release_year"] = int(year)
+                async for doc in db[collection].find(query).limit(limit):
+                    candidates.append(MatchCandidate(
+                        source="database",
+                        title=doc.get("title") or "",
+                        year=_safe_year(doc.get("release_year")),
+                        media_type=media_type,
+                        imdb_id=doc.get("imdb_id"),
+                        tmdb_id=doc.get("tmdb_id"),
+                        popularity=20.0,
+                        raw={"db_key": db_key, "db_index": doc.get("db_index")},
+                    ))
+                if len(candidates) >= limit:
+                    return candidates[:limit]
+    except Exception as e:
+        LOGGER.debug(f"Database metadata candidate lookup failed: {e}")
+    return candidates[:limit]
+
+
+async def _movie_candidates(variants: list[str], year=None, limit: int = 8) -> list[MatchCandidate]:
+    candidates: list[MatchCandidate] = []
+    candidates.extend(await _database_candidates(variants, "movie", year, limit=limit))
+
+    for title in variants:
+        try:
+            async with API_SEMAPHORE:
+                imdb_results = await search_titles(query=title, type="movie", limit=limit)
+            for result in imdb_results:
+                imdb_candidate = _imdb_candidate(result, "movie")
+                if imdb_candidate:
+                    candidates.append(imdb_candidate)
+        except Exception as e:
+            LOGGER.warning(f"IMDb movie candidate lookup failed for '{title}': {e}")
+
+        try:
+            async with API_SEMAPHORE:
+                tmdb_results = await tmdb.search().movies(query=title, year=year) if year else await tmdb.search().movies(query=title)
+            if not tmdb_results and year:
+                async with API_SEMAPHORE:
+                    tmdb_results = await tmdb.search().movies(query=title)
+            for item in (tmdb_results or [])[:limit]:
+                tmdb_id = getattr(item, "id", None)
+                if not tmdb_id:
+                    continue
+                candidates.append(MatchCandidate(
+                    source="tmdb",
+                    title=getattr(item, "title", "") or "",
+                    year=_tmdb_year(item, "release_date"),
+                    media_type="movie",
+                    tmdb_id=tmdb_id,
+                    popularity=float(getattr(item, "popularity", 0.0) or 0.0),
+                    raw=item,
+                ))
+        except Exception as e:
+            LOGGER.warning(f"TMDb movie candidate lookup failed for '{title}': {e}")
+    return _dedupe_candidates(candidates)
+
+
+async def _tv_candidates(variants: list[str], year=None, limit: int = 8) -> list[MatchCandidate]:
+    candidates: list[MatchCandidate] = []
+    candidates.extend(await _database_candidates(variants, "tv", year, limit=limit))
+
+    for title in variants:
+        try:
+            async with API_SEMAPHORE:
+                imdb_results = await search_titles(query=title, type="tvSeries", limit=limit)
+            for result in imdb_results:
+                imdb_candidate = _imdb_candidate(result, "tv")
+                if imdb_candidate:
+                    candidates.append(imdb_candidate)
+        except Exception as e:
+            LOGGER.warning(f"IMDb TV candidate lookup failed for '{title}': {e}")
+
+        try:
+            async with API_SEMAPHORE:
+                tmdb_results = await tmdb.search().tv(query=title)
+            for item in (tmdb_results or [])[:limit]:
+                tmdb_id = getattr(item, "id", None)
+                if not tmdb_id:
+                    continue
+                candidates.append(MatchCandidate(
+                    source="tmdb",
+                    title=getattr(item, "name", "") or "",
+                    year=_tmdb_year(item, "first_air_date"),
+                    media_type="tv",
+                    tmdb_id=tmdb_id,
+                    popularity=float(getattr(item, "popularity", 0.0) or 0.0),
+                    raw=item,
+                ))
+        except Exception as e:
+            LOGGER.warning(f"TMDb TV candidate lookup failed for '{title}': {e}")
+    return _dedupe_candidates(candidates)
+
+
+async def resolve_movie_match(title: str, year=None, raw_title: str | None = None, parsed: dict | None = None) -> tuple[MatchCandidate | None, dict]:
+    variants = build_title_variants(
+        raw_title=raw_title or title,
+        parsed_title=title,
+        year=_safe_year(year),
+        site=(parsed or {}).get("site"),
+    )
+    variants = variants or [normalize_title(title)]
+    intent = MatchIntent(
+        raw_title=title,
+        clean_title=variants[0],
+        year=_safe_year(year),
+        media_type="movie",
+        title_variants=variants,
+    )
+    decision = choose_best_candidate(intent, await _movie_candidates(variants, year))
+    return decision.candidate if decision.accepted else None, decision_metadata(decision, intent)
+
+
+async def resolve_tv_match(title: str, season=None, episode=None, year=None, season_pack: bool = False, raw_title: str | None = None, parsed: dict | None = None) -> tuple[MatchCandidate | None, dict]:
+    variants = build_title_variants(
+        raw_title=raw_title or title,
+        parsed_title=title,
+        year=_safe_year(year),
+        site=(parsed or {}).get("site"),
+    )
+    variants = variants or [normalize_title(title)]
+    intent = MatchIntent(
+        raw_title=title,
+        clean_title=variants[0],
+        year=_safe_year(year),
+        media_type="tv",
+        title_variants=variants,
+        season=season,
+        episode=episode,
+        season_pack=season_pack,
+    )
+    decision = choose_best_candidate(intent, await _tv_candidates(variants, year))
+    return decision.candidate if decision.accepted else None, decision_metadata(decision, intent)
+
+
+async def _retry_api_call(label: str, func, attempts: int = 3, base_delay: float = 0.8):
+    last_error = None
+    for attempt in range(1, attempts + 1):
+        try:
+            return await func()
+        except Exception as e:
+            last_error = e
+            if attempt < attempts:
+                await asyncio.sleep(base_delay * attempt)
+    LOGGER.warning(f"{label} failed after {attempts} attempts: {last_error}")
+    return None
 
 async def _tmdb_movie_details(movie_id):
     if movie_id in TMDB_DETAILS_CACHE:
         return TMDB_DETAILS_CACHE[movie_id]
-    try:
+
+    async def fetch():
         async with API_SEMAPHORE:
             details = await tmdb.movie(movie_id).details(
                 append_to_response="external_ids,credits"
             )
             images = await tmdb.movie(movie_id).images()
             details.images = images
+            return details
 
+    details = await _retry_api_call(f"TMDb movie details fetch id={movie_id}", fetch)
+    if details:
         TMDB_DETAILS_CACHE[movie_id] = details
         return details
-    except Exception as e:
-        LOGGER.warning(f"TMDb movie details fetch failed for id={movie_id}: {e}")
-        TMDB_DETAILS_CACHE[movie_id] = None
-        return None
+    return None
 
 
 async def _tmdb_tv_details(tv_id):
     if tv_id in TMDB_DETAILS_CACHE:
         return TMDB_DETAILS_CACHE[tv_id]
-    try:
+
+    async def fetch():
         async with API_SEMAPHORE:
             details = await tmdb.tv(tv_id).details(
                 append_to_response="external_ids,credits"
             )
             images = await tmdb.tv(tv_id).images()
             details.images = images
+            return details
+
+    details = await _retry_api_call(f"TMDb tv details fetch id={tv_id}", fetch)
+    if details:
         TMDB_DETAILS_CACHE[tv_id] = details
         return details
-    except Exception as e:
-        LOGGER.warning(f"TMDb tv details fetch failed for id={tv_id}: {e}")
-        TMDB_DETAILS_CACHE[tv_id] = None
-        return None
+    return None
 
 
 async def _tmdb_episode_details(tv_id, season, episode):
     key = (tv_id, season, episode)
     if key in EPISODE_CACHE:
         return EPISODE_CACHE[key]
-    try:
+
+    async def fetch():
         async with API_SEMAPHORE:
-            details = await tmdb.episode(tv_id, season, episode).details()
+            return await tmdb.episode(tv_id, season, episode).details()
+
+    details = await _retry_api_call(f"TMDb episode details fetch id={tv_id} S{season}E{episode}", fetch, attempts=2)
+    if details:
         EPISODE_CACHE[key] = details
         return details
+    return None
+
+
+def _year_from_date(value) -> int:
+    try:
+        return int(getattr(value, "year", 0) or 0)
     except Exception:
-        EPISODE_CACHE[key] = None
-        return None
+        return 0
+
+
+def _date_to_iso(value) -> str:
+    try:
+        return value.strftime("%Y-%m-%dT05:00:00.000Z") if value else ""
+    except Exception:
+        return ""
+
+
+def _tmdb_tv_fallback(search_result, title, season, episode, encoded_string, quality) -> dict:
+    return {
+        "tmdb_id": getattr(search_result, "id", None),
+        "imdb_id": None,
+        "title": getattr(search_result, "name", None) or title,
+        "year": _year_from_date(getattr(search_result, "first_air_date", None)),
+        "rate": getattr(search_result, "vote_average", 0) or 0,
+        "description": getattr(search_result, "overview", "") or "",
+        "poster": format_tmdb_image(getattr(search_result, "poster_path", None)),
+        "backdrop": format_tmdb_image(getattr(search_result, "backdrop_path", None), "original"),
+        "logo": "",
+        "genres": [],
+        "media_type": "tv",
+        "cast": [],
+        "runtime": "",
+        "season_number": season,
+        "episode_number": episode,
+        "episode_title": f"S{season}E{episode}",
+        "episode_backdrop": "",
+        "episode_overview": "",
+        "episode_released": "",
+        "quality": quality,
+        "encoded_string": encoded_string,
+    }
+
+
+def _tmdb_movie_fallback(search_result, title, encoded_string, year, quality) -> dict:
+    return {
+        "tmdb_id": getattr(search_result, "id", None),
+        "imdb_id": None,
+        "title": getattr(search_result, "title", None) or getattr(search_result, "name", None) or title,
+        "year": _year_from_date(getattr(search_result, "release_date", None)) or (year or 0),
+        "rate": getattr(search_result, "vote_average", 0) or 0,
+        "description": getattr(search_result, "overview", "") or "",
+        "poster": format_tmdb_image(getattr(search_result, "poster_path", None)),
+        "backdrop": format_tmdb_image(getattr(search_result, "backdrop_path", None), "original"),
+        "logo": "",
+        "cast": [],
+        "runtime": "",
+        "media_type": "movie",
+        "genres": [],
+        "quality": quality,
+        "encoded_string": encoded_string,
+    }
 
 # ----------------- Main Metadata -----------------
 async def metadata(filename: str, channel: int, msg_id, override_id: str = None) -> dict | None:
@@ -157,11 +489,6 @@ async def metadata(filename: str, channel: int, msg_id, override_id: str = None)
         parsed = PTN.parse(filename)
     except Exception as e:
         LOGGER.error(f"PTN parsing failed for {filename}: {e}\n{traceback.format_exc()}")
-        return None
-
-    # Skip combined/invalid files
-    if "excess" in parsed and any("combined" in item.lower() for item in parsed["excess"]):
-        LOGGER.info(f"Skipping {filename}: contains 'combined'")
         return None
 
     # Skip split/multipart files
@@ -175,16 +502,20 @@ async def metadata(filename: str, channel: int, msg_id, override_id: str = None)
     season = parsed.get("season")
     episode = parsed.get("episode")
     year = parsed.get("year")
-    quality = parsed.get("resolution")
+    quality = parsed.get("resolution") or infer_resolution_from_filename(filename, parsed)
     if isinstance(season, list) or isinstance(episode, list):
         LOGGER.warning(f"Invalid season/episode format for {filename}: {parsed}")
         return None
     if season and not episode:
-        LOGGER.warning(f"Missing episode in {filename}: {parsed}")
-        return None
+        is_season_pack = has_combined_marker(filename, parsed)
+        if not is_season_pack:
+            LOGGER.warning(f"Missing episode in {filename}: {parsed}")
+            return None
     if not quality:
-        LOGGER.warning(f"Skipping {filename}: No resolution (parsed={parsed})")
-        return None
+        quality = "SD"
+
+    if not parsed.get("resolution"):
+        LOGGER.info(f"No explicit resolution in {filename}; inferred quality={quality}")
     if not title:
         LOGGER.info(f"No title parsed from: {filename} (parsed={parsed})")
         return None
@@ -209,6 +540,8 @@ async def metadata(filename: str, channel: int, msg_id, override_id: str = None)
         except Exception:
             pass
 
+    explicit_default_id = bool(default_id)
+
     data = {"chat_id": channel, "msg_id": msg_id}
     try:
         encoded_string = await encode_string(data)
@@ -218,15 +551,111 @@ async def metadata(filename: str, channel: int, msg_id, override_id: str = None)
     try:
         if season and episode:
             LOGGER.info(f"Fetching TV metadata: {title} S{season}E{episode}")
+            if not explicit_default_id and not default_id:
+                candidate, match_details = await resolve_tv_match(title, season, episode, year, raw_title=filename, parsed=parsed)
+                if not candidate:
+                    set_match_failure(channel, msg_id, match_details)
+                    LOGGER.warning(f"Strict TV metadata match rejected for {filename}: {match_details.get('match_rejection_reason')}")
+                    return None
+                default_id = candidate.imdb_id or candidate.tmdb_id
             return await fetch_tv_metadata(title, season, episode, encoded_string, year, quality, default_id)
+        elif season:
+            LOGGER.info(f"Fetching TV season-pack metadata: {title} S{season}")
+            if not explicit_default_id and not default_id:
+                candidate, match_details = await resolve_tv_match(title, season, None, year, season_pack=True, raw_title=filename, parsed=parsed)
+                if not candidate:
+                    set_match_failure(channel, msg_id, match_details)
+                    LOGGER.warning(f"Strict TV season-pack metadata match rejected for {filename}: {match_details.get('match_rejection_reason')}")
+                    return None
+                default_id = candidate.imdb_id or candidate.tmdb_id
+            return await fetch_tv_season_pack_metadata(title, season, encoded_string, year, quality, default_id)
         else:
             LOGGER.info(f"Fetching Movie metadata: {title} ({year})")
+            if not explicit_default_id and not default_id:
+                candidate, match_details = await resolve_movie_match(title, year, raw_title=filename, parsed=parsed)
+                if not candidate:
+                    set_match_failure(channel, msg_id, match_details)
+                    LOGGER.warning(f"Strict movie metadata match rejected for {filename}: {match_details.get('match_rejection_reason')}")
+                    return None
+                default_id = candidate.imdb_id or candidate.tmdb_id
             return await fetch_movie_metadata(title, encoded_string, year, quality, default_id)
     except Exception as e:
         LOGGER.error(f"Error while fetching metadata for {filename}: {e}\n{traceback.format_exc()}")
         return None
 
 # ----------------- TV Metadata -----------------
+async def _get_tmdb_tv_id(title, year=None, default_id=None):
+    if default_id:
+        default_id = str(default_id).strip()
+        if default_id.isdigit():
+            return int(default_id)
+
+    tmdb_search = await safe_tmdb_search(title, "tv", year)
+    return tmdb_search.id if tmdb_search else None
+
+
+async def _get_season_episode_count(title, season, year=None, default_id=None) -> int:
+    try:
+        tmdb_id = await _get_tmdb_tv_id(title, year, default_id)
+        if not tmdb_id:
+            return 1
+
+        tv = await _tmdb_tv_details(tmdb_id)
+        if not tv:
+            return 1
+        for season_info in getattr(tv, "seasons", []) or []:
+            if int(getattr(season_info, "season_number", -1) or -1) == int(season):
+                count = int(getattr(season_info, "episode_count", 0) or 0)
+                return max(1, count)
+    except Exception as e:
+        LOGGER.warning(f"Could not determine episode count for {title} S{season}: {e}")
+
+    return 1
+
+
+async def fetch_tv_season_pack_metadata(title, season, encoded_string, year=None, quality=None, default_id=None) -> dict | None:
+    base = await fetch_tv_metadata(title, season, 1, encoded_string, year, quality, default_id)
+    if not base:
+        return None
+
+    episode_count = await _get_season_episode_count(title, season, year, default_id)
+    tmdb_id = base.get("tmdb_id")
+    episodes = []
+
+    for episode_number in range(1, episode_count + 1):
+        ep_details = None
+        if tmdb_id:
+            try:
+                ep_details = await _tmdb_episode_details(int(tmdb_id), season, episode_number)
+            except Exception:
+                ep_details = None
+
+        episodes.append(
+            {
+                "episode_number": episode_number,
+                "episode_title": getattr(ep_details, "name", f"Episode {episode_number}") if ep_details else f"Episode {episode_number}",
+                "episode_backdrop": format_tmdb_image(getattr(ep_details, "still_path", None), "original") if ep_details else "",
+                "episode_overview": getattr(ep_details, "overview", "") if ep_details else "",
+                "episode_released": (
+                    ep_details.air_date.strftime("%Y-%m-%dT05:00:00.000Z")
+                    if getattr(ep_details, "air_date", None)
+                    else ""
+                ),
+            }
+        )
+
+    base.update(
+        {
+            "season_pack": True,
+            "season_pack_episode_count": episode_count,
+            "season_pack_episodes": episodes,
+            "episode_number": 1,
+            "episode_title": f"Season {int(season):02d} Pack",
+        }
+    )
+    return base
+
+
 async def fetch_tv_metadata(title, season, episode, encoded_string, year=None, quality=None, default_id=None) -> dict | None:
     imdb_id = None
     tmdb_id = None
@@ -295,6 +724,7 @@ async def fetch_tv_metadata(title, season, episode, encoded_string, year=None, q
     # =======================================================
     if must_use_tmdb:
         LOGGER.info(f"No valid IMDb TV data for '{title}' → using TMDb")
+        tmdb_search = None
 
         # Search TMDb by title
         if not tmdb_id:
@@ -308,7 +738,31 @@ async def fetch_tv_metadata(title, season, episode, encoded_string, year=None, q
         tv = await _tmdb_tv_details(tmdb_id)
         if not tv:
             LOGGER.warning(f"TMDb TV details failed for id={tmdb_id}")
-            return None
+            if tmdb_search:
+                return _tmdb_tv_fallback(tmdb_search, title, season, episode, encoded_string, quality)
+            return {
+                "tmdb_id": tmdb_id,
+                "imdb_id": None,
+                "title": title,
+                "year": year or 0,
+                "rate": 0,
+                "description": "",
+                "poster": "",
+                "backdrop": "",
+                "logo": "",
+                "genres": [],
+                "media_type": "tv",
+                "cast": [],
+                "runtime": "",
+                "season_number": season,
+                "episode_number": episode,
+                "episode_title": f"S{season}E{episode}",
+                "episode_backdrop": "",
+                "episode_overview": "",
+                "episode_released": "",
+                "quality": quality,
+                "encoded_string": encoded_string,
+            }
 
         # Fetch episode
         ep = await _tmdb_episode_details(tmdb_id, season, episode)
@@ -349,11 +803,7 @@ async def fetch_tv_metadata(title, season, episode, encoded_string, year=None, q
             "episode_title": getattr(ep, "name", f"S{season}E{episode}") if ep else f"S{season}E{episode}",
             "episode_backdrop": format_tmdb_image(getattr(ep, "still_path", None), "original") if ep else "",
             "episode_overview": getattr(ep, "overview", "") if ep else "",
-            "episode_released": (
-                ep.air_date.strftime("%Y-%m-%dT05:00:00.000Z")
-                if getattr(ep, "air_date", None)
-                else ""
-            ),
+            "episode_released": _date_to_iso(getattr(ep, "air_date", None)),
 
             "quality": quality,
             "encoded_string": encoded_string,
@@ -394,140 +844,6 @@ async def fetch_tv_metadata(title, season, episode, encoded_string, year=None, q
     }
 
 
-# ----------------- Movie Metadata -----------------
-async def fetch_movie_metadata(title, encoded_string, year=None, quality=None, default_id=None) -> dict | None:
-    imdb_id = None
-    tmdb_id = None
-    imdb_details = None
-    use_tmdb = False
-
-    # -------------------------------------------------------
-    # 1. PROCESS DEFAULT ID (tt = IMDb, digits = TMDb)
-    # -------------------------------------------------------
-    if default_id:
-        default_id = str(default_id).strip()
-
-        if default_id.startswith("tt"):
-            imdb_id = default_id
-            use_tmdb = False                       
-        elif default_id.isdigit():
-            tmdb_id = int(default_id)
-            use_tmdb = True                       
-
-    # -------------------------------------------------------
-    # 2. IF NO DEFAULT ID → SEARCH IMDb FIRST
-    # -------------------------------------------------------
-    if not imdb_id and not tmdb_id:
-        imdb_id = await safe_imdb_search(
-            f"{title} {year}" if year else title,
-            "movie"
-        )
-        use_tmdb = not bool(imdb_id)
-
-    # -------------------------------------------------------
-    # 3. FETCH IMDb DETAILS (only if imdb_id exists)
-    # -------------------------------------------------------
-    if imdb_id and not use_tmdb:
-        try:
-            if imdb_id in IMDB_CACHE:
-                imdb_details = IMDB_CACHE[imdb_id]
-            else:
-                async with API_SEMAPHORE:
-                    imdb_details = await get_detail(
-                        imdb_id=imdb_id,
-                        media_type="movie"
-                    )
-
-                IMDB_CACHE[imdb_id] = imdb_details
-
-        except Exception as e:
-            LOGGER.warning(f"IMDb movie fetch failed [{title}] → {e}")
-            imdb_details = None
-            use_tmdb = True
-
-    # -------------------------------------------------------
-    # 4. DECIDE FINAL DATA SOURCE
-    # -------------------------------------------------------
-    must_use_tmdb = (
-        use_tmdb or
-        imdb_details is None or
-        imdb_details == {}
-    )
-
-    # =======================================================
-    #  5. TMDb MODE
-    # =======================================================
-    if must_use_tmdb:
-        LOGGER.info(f"No valid IMDb data for '{title}' → using TMDb")
-
-        # TMDb search if id unknown
-        if not tmdb_id:
-            tmdb_result = await safe_tmdb_search(title, "movie", year)
-            if not tmdb_result:
-                LOGGER.warning(f"No TMDb movie found for '{title}'")
-                return None
-            tmdb_id = tmdb_result.id
-
-        # Fetch TMDb details
-        movie = await _tmdb_movie_details(tmdb_id)
-        if not movie:
-            LOGGER.warning(f"TMDb details failed for {tmdb_id}")
-            return None
-
-        # Cast extraction
-        credits = getattr(movie, "credits", None) or {}
-        cast_arr = getattr(credits, "cast", []) or []
-        cast_names = [
-            getattr(c, "name", None) or getattr(c, "original_name", None)
-            for c in cast_arr
-        ]
-
-        runtime_val = getattr(movie, "runtime", None)
-        runtime = f"{runtime_val} min" if runtime_val else ""
-
-        return {
-            "tmdb_id": movie.id,
-            "imdb_id": getattr(movie.external_ids, "imdb_id", None),
-            "title": movie.title,
-            "year": getattr(movie.release_date, "year", 0) if getattr(movie, "release_date", None) else 0,
-            "rate": getattr(movie, "vote_average", 0) or 0,
-            "description": movie.overview or "",
-            "poster": format_tmdb_image(movie.poster_path),
-            "backdrop": format_tmdb_image(movie.backdrop_path, "original"),
-            "logo": get_tmdb_logo(getattr(movie, "images", None)),
-            "cast": cast_names,
-            "runtime": str(runtime),
-            "media_type": "movie",
-            "genres": [g.name for g in (movie.genres or [])],
-            "quality": quality,
-            "encoded_string": encoded_string,
-        }
-
-    # =======================================================
-    #  6. IMDb MODE
-    # =======================================================
-    images = format_imdb_images(imdb_id)
-    imdb = imdb_details or {}
-
-    return {
-        "tmdb_id": imdb.get("moviedb_id") or imdb_id.replace("tt", ""),
-        "imdb_id": imdb_id,
-        "title": imdb.get("title", title),
-        "year": imdb.get("releaseDetailed", {}).get("year", 0),
-        "rate": imdb.get("rating", {}).get("star", 0),
-        "description": imdb.get("plot", ""),
-        "poster": images["poster"],
-        "backdrop": images["backdrop"],
-        "logo": images["logo"],
-        "cast": imdb.get("cast", []),
-        "runtime": str(imdb.get("runtime") or ""),
-        "media_type": "movie",
-        "genres": imdb.get("genre", []),
-        "quality": quality,
-        "encoded_string": encoded_string,
-    }
-
-
 async def search_movie_candidates(query: str, year: int | None = None, limit: int = 8) -> list[dict]:
     query = (query or "").strip()
     if not query:
@@ -536,7 +852,6 @@ async def search_movie_candidates(query: str, year: int | None = None, limit: in
     results: list[dict] = []
     seen: set[tuple[str, str]] = set()
 
-    # IMDb/Cinemeta top result
     try:
         imdb_result = await search_title(query=query, type="movie")
         if imdb_result and imdb_result.get("id"):
@@ -556,7 +871,6 @@ async def search_movie_candidates(query: str, year: int | None = None, limit: in
     except Exception as e:
         LOGGER.warning(f"IMDb movie candidate search failed for '{query}': {e}")
 
-    # TMDb multiple results
     try:
         async with API_SEMAPHORE:
             tmdb_results = await tmdb.search().movies(query=query, year=year) if year else await tmdb.search().movies(query=query)
@@ -606,7 +920,6 @@ async def search_tv_candidates(query: str, limit: int = 8) -> list[dict]:
     results: list[dict] = []
     seen: set[tuple[str, str]] = set()
 
-    # IMDb/Cinemeta top result
     try:
         imdb_result = await search_title(query=query, type="tvSeries")
         if imdb_result and imdb_result.get("id"):
@@ -626,7 +939,6 @@ async def search_tv_candidates(query: str, limit: int = 8) -> list[dict]:
     except Exception as e:
         LOGGER.warning(f"IMDb TV candidate search failed for '{query}': {e}")
 
-    # TMDb multiple results
     try:
         async with API_SEMAPHORE:
             tmdb_results = await tmdb.search().tv(query=query)
@@ -780,4 +1092,157 @@ async def fetch_selected_tv_metadata(selected_id: str) -> dict | None:
         "cast": imdb_tv.get("cast", []),
         "runtime": str(imdb_tv.get("runtime") or ""),
         "media_type": "tv",
+    }
+
+
+# ----------------- Movie Metadata -----------------
+async def fetch_movie_metadata(title, encoded_string, year=None, quality=None, default_id=None) -> dict | None:
+    imdb_id = None
+    tmdb_id = None
+    imdb_details = None
+    use_tmdb = False
+
+    # -------------------------------------------------------
+    # 1. PROCESS DEFAULT ID (tt = IMDb, digits = TMDb)
+    # -------------------------------------------------------
+    if default_id:
+        default_id = str(default_id).strip()
+
+        if default_id.startswith("tt"):
+            imdb_id = default_id
+            use_tmdb = False                       
+        elif default_id.isdigit():
+            tmdb_id = int(default_id)
+            use_tmdb = True                       
+
+    # -------------------------------------------------------
+    # 2. IF NO DEFAULT ID → SEARCH IMDb FIRST
+    # -------------------------------------------------------
+    if not imdb_id and not tmdb_id:
+        imdb_id = await safe_imdb_search(
+            f"{title} {year}" if year else title,
+            "movie"
+        )
+        use_tmdb = not bool(imdb_id)
+
+    # -------------------------------------------------------
+    # 3. FETCH IMDb DETAILS (only if imdb_id exists)
+    # -------------------------------------------------------
+    if imdb_id and not use_tmdb:
+        try:
+            if imdb_id in IMDB_CACHE:
+                imdb_details = IMDB_CACHE[imdb_id]
+            else:
+                async with API_SEMAPHORE:
+                    imdb_details = await get_detail(
+                        imdb_id=imdb_id,
+                        media_type="movie"
+                    )
+
+                IMDB_CACHE[imdb_id] = imdb_details
+
+        except Exception as e:
+            LOGGER.warning(f"IMDb movie fetch failed [{title}] → {e}")
+            imdb_details = None
+            use_tmdb = True
+
+    # -------------------------------------------------------
+    # 4. DECIDE FINAL DATA SOURCE
+    # -------------------------------------------------------
+    must_use_tmdb = (
+        use_tmdb or
+        imdb_details is None or
+        imdb_details == {}
+    )
+
+    # =======================================================
+    #  5. TMDb MODE
+    # =======================================================
+    if must_use_tmdb:
+        LOGGER.info(f"No valid IMDb data for '{title}' → using TMDb")
+        tmdb_result = None
+
+        # TMDb search if id unknown
+        if not tmdb_id:
+            tmdb_result = await safe_tmdb_search(title, "movie", year)
+            if not tmdb_result:
+                LOGGER.warning(f"No TMDb movie found for '{title}'")
+                return None
+            tmdb_id = tmdb_result.id
+
+        # Fetch TMDb details
+        movie = await _tmdb_movie_details(tmdb_id)
+        if not movie:
+            LOGGER.warning(f"TMDb details failed for {tmdb_id}")
+            if tmdb_result:
+                return _tmdb_movie_fallback(tmdb_result, title, encoded_string, year, quality)
+            return {
+                "tmdb_id": tmdb_id,
+                "imdb_id": None,
+                "title": title,
+                "year": year or 0,
+                "rate": 0,
+                "description": "",
+                "poster": "",
+                "backdrop": "",
+                "logo": "",
+                "cast": [],
+                "runtime": "",
+                "media_type": "movie",
+                "genres": [],
+                "quality": quality,
+                "encoded_string": encoded_string,
+            }
+
+        # Cast extraction
+        credits = getattr(movie, "credits", None) or {}
+        cast_arr = getattr(credits, "cast", []) or []
+        cast_names = [
+            getattr(c, "name", None) or getattr(c, "original_name", None)
+            for c in cast_arr
+        ]
+
+        runtime_val = getattr(movie, "runtime", None)
+        runtime = f"{runtime_val} min" if runtime_val else ""
+
+        return {
+            "tmdb_id": movie.id,
+            "imdb_id": getattr(movie.external_ids, "imdb_id", None),
+            "title": movie.title,
+            "year": getattr(movie.release_date, "year", 0) if getattr(movie, "release_date", None) else 0,
+            "rate": getattr(movie, "vote_average", 0) or 0,
+            "description": movie.overview or "",
+            "poster": format_tmdb_image(movie.poster_path),
+            "backdrop": format_tmdb_image(movie.backdrop_path, "original"),
+            "logo": get_tmdb_logo(getattr(movie, "images", None)),
+            "cast": cast_names,
+            "runtime": str(runtime),
+            "media_type": "movie",
+            "genres": [g.name for g in (movie.genres or [])],
+            "quality": quality,
+            "encoded_string": encoded_string,
+        }
+
+    # =======================================================
+    #  6. IMDb MODE
+    # =======================================================
+    images = format_imdb_images(imdb_id)
+    imdb = imdb_details or {}
+
+    return {
+        "tmdb_id": imdb.get("moviedb_id") or imdb_id.replace("tt", ""),
+        "imdb_id": imdb_id,
+        "title": imdb.get("title", title),
+        "year": imdb.get("releaseDetailed", {}).get("year", 0),
+        "rate": imdb.get("rating", {}).get("star", 0),
+        "description": imdb.get("plot", ""),
+        "poster": images["poster"],
+        "backdrop": images["backdrop"],
+        "logo": images["logo"],
+        "cast": imdb.get("cast", []),
+        "runtime": str(imdb.get("runtime") or ""),
+        "media_type": "movie",
+        "genres": imdb.get("genre", []),
+        "quality": quality,
+        "encoded_string": encoded_string,
     }

--- a/Backend/helper/metadata_matcher.py
+++ b/Backend/helper/metadata_matcher.py
@@ -1,0 +1,278 @@
+import re
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from typing import Any
+
+try:
+    from rapidfuzz import fuzz
+except Exception:  # pragma: no cover - optional runtime acceleration
+    fuzz = None
+
+
+NOISE_WORDS = {
+    "amzn", "amazon", "nf", "netflix", "zee5", "hotstar", "jio", "sony", "liv",
+    "web", "webdl", "web-dl", "webrip", "dl", "hdrip", "brrip", "bluray", "blu-ray",
+    "hdtv", "dvdrip", "remux", "proper", "repack", "extended", "uncut",
+    "h264", "h265", "x264", "x265", "hevc", "av1", "10bit", "8bit",
+    "ddp", "dd", "aac", "atmos", "dts", "truehd", "5.1", "7.1",
+    "1080p", "720p", "2160p", "480p", "4k", "uhd", "hdr", "dv",
+    "tamil", "telugu", "malayalam", "hindi", "english", "kannada", "bengali",
+    "mkv", "mp4", "avi", "webm", "mov", "flv", "wmv", "m4v",
+}
+
+RELEASE_SITE_WORDS = {
+    "www", "com", "org", "net", "in", "cc", "cards", "card", "site",
+    "1tamilmv", "tamilmv", "tamilmvbiz", "1tamilblasters", "tamilblasters",
+    "moviesda", "isaimini", "tamilrockers", "movierulz", "telegram",
+}
+
+GENERIC_TITLES = {
+    "patriot", "war", "master", "hero", "leo", "animal", "jawan", "king",
+    "queen", "love", "life", "ghost", "beast", "vikram", "don", "boss",
+}
+
+
+@dataclass
+class MatchIntent:
+    raw_title: str
+    clean_title: str
+    year: int | None
+    media_type: str
+    title_variants: list[str] | None = None
+    season: int | None = None
+    episode: int | None = None
+    season_pack: bool = False
+    quality: str | None = None
+
+
+@dataclass
+class MatchCandidate:
+    source: str
+    title: str
+    year: int | None
+    media_type: str
+    imdb_id: str | None = None
+    tmdb_id: int | str | None = None
+    popularity: float = 0.0
+    raw: Any = None
+
+
+@dataclass
+class MatchDecision:
+    accepted: bool
+    candidate: MatchCandidate | None
+    confidence: float
+    reason: str
+    candidates: list[dict]
+
+
+def normalize_title(value: str | None) -> str:
+    value = (value or "").lower()
+    value = re.sub(r"https?://\S+", " ", value)
+    value = re.sub(r"\b(?:19|20)\d{2}\b", " ", value)
+    value = re.sub(r"\bs\d{1,2}e\d{1,2}\b", " ", value)
+    value = re.sub(r"\bs\d{1,2}\b", " ", value)
+    value = re.sub(r"[\._\-+\[\]\(\)\{\}:;,/\\|]+", " ", value)
+    words = []
+    for word in re.findall(r"[a-z0-9]+(?:'[a-z0-9]+)?", value):
+        if word in NOISE_WORDS:
+            continue
+        if len(word) == 1:
+            continue
+        if word.isdigit() and len(word) <= 2:
+            continue
+        if re.fullmatch(r"\d{3,4}p?", word):
+            continue
+        words.append(word)
+    return " ".join(words).strip()
+
+
+def _tokenize_title(value: str | None) -> list[str]:
+    text = (value or "").lower()
+    text = re.sub(r"https?://\S+", " ", text)
+    text = re.sub(r"[\._\-+\[\]\(\)\{\}:;,/\\|]+", " ", text)
+    return re.findall(r"[a-z0-9]+(?:'[a-z0-9]+)?", text)
+
+
+def _drop_release_site_prefix(tokens: list[str]) -> list[str]:
+    out = list(tokens)
+    while out and (out[0] in RELEASE_SITE_WORDS or re.fullmatch(r"\d*tamilmv\d*", out[0] or "")):
+        out.pop(0)
+    return out
+
+
+def _variant_from_tokens(tokens: list[str]) -> str:
+    return normalize_title(" ".join(_drop_release_site_prefix(tokens)))
+
+
+def build_title_variants(raw_title: str | None, parsed_title: str | None = None, year: int | None = None, site: str | None = None) -> list[str]:
+    variants: list[str] = []
+
+    def add(value: str | None) -> None:
+        normalized = normalize_title(value)
+        if normalized and normalized not in variants:
+            variants.append(normalized)
+
+    def add_tokens(tokens: list[str]) -> None:
+        normalized = _variant_from_tokens(tokens)
+        if normalized and normalized not in variants:
+            variants.append(normalized)
+
+    if parsed_title:
+        add_tokens(_tokenize_title(parsed_title))
+        add(parsed_title)
+
+    raw_tokens = _tokenize_title(raw_title)
+    if raw_tokens:
+        year_index = None
+        for idx, token in enumerate(raw_tokens):
+            if token == str(year) or re.fullmatch(r"(?:19|20)\d{2}", token):
+                year_index = idx
+                break
+        if year_index is not None:
+            before_year = raw_tokens[:year_index]
+            add_tokens(before_year)
+            for start in range(len(before_year)):
+                add_tokens(before_year[start:])
+
+        add_tokens(raw_tokens)
+        if site:
+            site_tokens = set(_tokenize_title(site))
+            add_tokens([token for token in raw_tokens if token not in site_tokens])
+
+    return variants
+
+
+def title_similarity(left: str | None, right: str | None) -> float:
+    left_norm = normalize_title(left)
+    right_norm = normalize_title(right)
+    if not left_norm or not right_norm:
+        return 0.0
+    if left_norm == right_norm:
+        return 100.0
+    if fuzz:
+        if len(left_norm.split()) <= 1 or len(right_norm.split()) <= 1:
+            return float(max(
+                fuzz.ratio(left_norm, right_norm),
+                fuzz.token_sort_ratio(left_norm, right_norm),
+            ))
+        return float(max(
+            fuzz.ratio(left_norm, right_norm),
+            fuzz.token_sort_ratio(left_norm, right_norm),
+            fuzz.token_set_ratio(left_norm, right_norm),
+        ))
+    return SequenceMatcher(None, left_norm, right_norm).ratio() * 100.0
+
+
+def is_generic_title(title: str | None) -> bool:
+    normalized = normalize_title(title)
+    return normalized in GENERIC_TITLES or len(normalized.split()) <= 1
+
+
+def _year_score(intent_year: int | None, candidate_year: int | None) -> tuple[float, str | None]:
+    if not intent_year:
+        return 0.0, None
+    if not candidate_year:
+        return -12.0, "metadata_year_missing"
+    delta = abs(int(intent_year) - int(candidate_year))
+    if delta == 0:
+        return 18.0, None
+    if delta == 1:
+        return 8.0, None
+    return -80.0, "metadata_year_mismatch"
+
+
+def _candidate_public(candidate: MatchCandidate, score: float, title_score: float, reason: str | None) -> dict:
+    return {
+        "source": candidate.source,
+        "title": candidate.title,
+        "year": candidate.year,
+        "media_type": candidate.media_type,
+        "imdb_id": candidate.imdb_id,
+        "tmdb_id": candidate.tmdb_id,
+        "score": round(score, 2),
+        "title_score": round(title_score, 2),
+        "reason": reason,
+    }
+
+
+def _same_identity(left: MatchCandidate, right: MatchCandidate) -> bool:
+    if left.imdb_id and right.imdb_id and left.imdb_id == right.imdb_id:
+        return True
+    if left.tmdb_id and right.tmdb_id and str(left.tmdb_id) == str(right.tmdb_id):
+        return True
+    return (
+        left.media_type == right.media_type
+        and normalize_title(left.title) == normalize_title(right.title)
+        and left.year == right.year
+    )
+
+
+def choose_best_candidate(intent: MatchIntent, candidates: list[MatchCandidate]) -> MatchDecision:
+    scored: list[tuple[float, float, str | None, MatchCandidate]] = []
+    rejected_reason = "metadata_no_candidates"
+
+    for candidate in candidates:
+        reason = None
+        if candidate.media_type != intent.media_type:
+            reason = "metadata_media_type_mismatch"
+        variants = intent.title_variants or [intent.clean_title or intent.raw_title]
+        title_score = max(title_similarity(variant, candidate.title) for variant in variants)
+        year_bonus, year_reason = _year_score(intent.year, candidate.year)
+        if year_reason:
+            reason = year_reason
+
+        score = title_score + year_bonus + min(float(candidate.popularity or 0.0), 20.0) / 20.0
+        if reason:
+            score -= 100.0
+        scored.append((score, title_score, reason, candidate))
+
+    scored.sort(key=lambda item: item[0], reverse=True)
+    public = [_candidate_public(candidate, score, title_score, reason) for score, title_score, reason, candidate in scored[:8]]
+
+    if not scored:
+        return MatchDecision(False, None, 0.0, rejected_reason, public)
+
+    top_score, top_title_score, top_reason, top = scored[0]
+    second_score = -999.0
+    for score, _, _, candidate in scored[1:]:
+        if not _same_identity(top, candidate):
+            second_score = score
+            break
+    margin = top_score - second_score
+    generic = is_generic_title(intent.clean_title)
+
+    if top_reason:
+        return MatchDecision(False, top, top_score, top_reason, public)
+    if top.media_type != intent.media_type:
+        return MatchDecision(False, top, top_score, "metadata_media_type_mismatch", public)
+    if intent.year and top.year and abs(int(intent.year) - int(top.year)) > 1:
+        return MatchDecision(False, top, top_score, "metadata_year_mismatch", public)
+    if intent.year and not top.year:
+        return MatchDecision(False, top, top_score, "metadata_year_missing", public)
+    if generic and not intent.year:
+        return MatchDecision(False, top, top_score, "metadata_generic_title_needs_year", public)
+
+    min_title = 92.0 if generic else 86.0
+    min_margin = 8.0 if intent.year else 12.0
+    if generic:
+        min_margin = 12.0
+
+    if top_title_score < min_title:
+        return MatchDecision(False, top, top_score, "metadata_title_mismatch", public)
+    if second_score > -999.0 and margin < min_margin:
+        return MatchDecision(False, top, top_score, "metadata_ambiguous_match", public)
+
+    return MatchDecision(True, top, top_score, "accepted", public)
+
+
+def decision_metadata(decision: MatchDecision, intent: MatchIntent) -> dict:
+    return {
+        "parsed_title": intent.clean_title,
+        "parsed_year": intent.year,
+        "parsed_media_type": intent.media_type,
+        "search_variants": intent.title_variants or [intent.clean_title],
+        "match_confidence": round(decision.confidence, 2),
+        "match_rejection_reason": None if decision.accepted else decision.reason,
+        "match_candidates": decision.candidates,
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "python-dotenv>=1.1.0",
     "python-multipart>=0.0.20",
     "pytz>=2025.2",
+    "rapidfuzz>=3.13.0",
     "requests>=2.32.3",
     "tgcrypto>=1.2.5",
     "themoviedb>=1.0.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ parse-torrent-title
 pyrofork
 python-dotenv
 pytz
+rapidfuzz
 tgcrypto
 themoviedb
 uvicorn

--- a/tests/test_metadata_matcher.py
+++ b/tests/test_metadata_matcher.py
@@ -1,0 +1,119 @@
+import os
+import unittest
+
+os.environ.setdefault(
+    "DATABASE",
+    "mongodb://localhost:27017/matcher_tracking,mongodb://localhost:27017/matcher_storage",
+)
+
+from Backend.helper.metadata_matcher import (
+    MatchCandidate,
+    MatchIntent,
+    build_title_variants,
+    choose_best_candidate,
+    normalize_title,
+)
+
+
+class MetadataMatcherTests(unittest.TestCase):
+    def test_patriot_2026_rejects_the_patriot_2000(self):
+        intent = MatchIntent(
+            raw_title="Patriot",
+            clean_title="patriot",
+            year=2026,
+            media_type="movie",
+        )
+        decision = choose_best_candidate(intent, [
+            MatchCandidate("imdb", "The Patriot", 2000, "movie", imdb_id="tt0187393"),
+            MatchCandidate("tmdb", "Patriot", 2026, "movie", imdb_id="tt33412884", tmdb_id=123),
+        ])
+        self.assertTrue(decision.accepted)
+        self.assertEqual(decision.candidate.imdb_id, "tt33412884")
+
+    def test_wrong_year_candidate_is_rejected(self):
+        intent = MatchIntent(
+            raw_title="Patriot",
+            clean_title="patriot",
+            year=2026,
+            media_type="movie",
+        )
+        decision = choose_best_candidate(intent, [
+            MatchCandidate("imdb", "The Patriot", 2000, "movie", imdb_id="tt0187393"),
+        ])
+        self.assertFalse(decision.accepted)
+        self.assertEqual(decision.reason, "metadata_year_mismatch")
+
+    def test_duplicate_imdb_and_tmdb_same_title_is_not_ambiguous(self):
+        intent = MatchIntent(
+            raw_title="F9 The Fast Saga",
+            clean_title="f9 the fast saga",
+            year=2021,
+            media_type="movie",
+        )
+        decision = choose_best_candidate(intent, [
+            MatchCandidate("imdb", "F9: The Fast Saga", 2021, "movie", imdb_id="tt5433138", tmdb_id=385128),
+            MatchCandidate("tmdb", "F9", 2021, "movie", tmdb_id=385128),
+        ])
+        self.assertTrue(decision.accepted)
+
+    def test_generic_title_without_year_goes_unmatched(self):
+        intent = MatchIntent(
+            raw_title="War",
+            clean_title="war",
+            year=None,
+            media_type="movie",
+        )
+        decision = choose_best_candidate(intent, [
+            MatchCandidate("imdb", "War", 2019, "movie", imdb_id="tt7430722"),
+        ])
+        self.assertFalse(decision.accepted)
+        self.assertEqual(decision.reason, "metadata_generic_title_needs_year")
+
+    def test_normalize_title_removes_release_noise(self):
+        self.assertEqual(
+            normalize_title("Patriot.2026.Malayalam.1080p.ZEE5.WEB-DL.DD+5.1.H.264-JeRi.mkv"),
+            "patriot jeri",
+        )
+
+    def test_release_site_prefix_builds_clean_title_variant(self):
+        variants = build_title_variants(
+            raw_title="www_1TamilMV_cards_Patriot_2026_TRUE_WEB_DL_1080p_AVC.mkv",
+            parsed_title="www 1TamilMV cards Patriot",
+            year=2026,
+        )
+        self.assertEqual(variants[0], "patriot")
+        self.assertIn("patriot", variants)
+
+    def test_clean_variant_accepts_correct_generic_title(self):
+        intent = MatchIntent(
+            raw_title="www 1TamilMV cards Patriot",
+            clean_title="www 1tamilmv cards patriot",
+            year=2026,
+            media_type="movie",
+            title_variants=["patriot", "www 1tamilmv cards patriot"],
+        )
+        decision = choose_best_candidate(intent, [
+            MatchCandidate("imdb", "The Patriot", 2000, "movie", imdb_id="tt0187393"),
+            MatchCandidate("database", "Patriot", 2026, "movie", imdb_id="tt33412884", tmdb_id=1300501),
+        ])
+        self.assertTrue(decision.accepted)
+        self.assertEqual(decision.candidate.imdb_id, "tt33412884")
+
+    def test_generic_exact_title_beats_partial_title_with_same_year(self):
+        intent = MatchIntent(
+            raw_title="Patriot",
+            clean_title="patriot",
+            year=2026,
+            media_type="movie",
+            title_variants=["patriot"],
+        )
+        decision = choose_best_candidate(intent, [
+            MatchCandidate("tmdb", "Patriot", 2026, "movie", tmdb_id=1300501),
+            MatchCandidate("tmdb", "Antoni Patek, Patriot and Watchmaker", 2025, "movie", tmdb_id=1600775),
+        ])
+        self.assertTrue(decision.accepted)
+        self.assertEqual(decision.candidate.tmdb_id, 1300501)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Improves metadata selection during Telegram ingestion so uploads do not silently index into the wrong movie/show when search results are ambiguous.

## What changed

- adds a candidate-ranking matcher for title/year/media-type confidence
- normalizes noisy release filenames before comparison
- prefers exact/near-exact title and year matches
- rejects strong year or media-type conflicts
- keeps explicit IMDb/TMDb links as user-confirmed overrides
- returns `None` for uncertain matches instead of accepting the first search result

## Why

This prevents cases like `Patriot.2026...` being indexed as `The Patriot (2000)`.

## Tests

- `python -m compileall Backend tests`
- `python -m unittest discover -v`