### PR TITLE
Add unmatched media repair page

### DIFF
--- a/Backend/fastapi/main.py
+++ b/Backend/fastapi/main.py
@@ -12,7 +12,7 @@ from Backend.fastapi.routes.template_routes import (
     login_page, login_post, logout, set_theme, dashboard_page,
     media_management_page, edit_media_page, public_status_page, stremio_guide_page,
     admin_dashboard_page, admin_subscriptions_page, admin_access_page,
-    custom_catalogs_page
+    custom_catalogs_page, unmatched_media_page
 )
 from Backend.fastapi.routes.api_routes import (
     list_media_api, delete_media_api, update_media_api,
@@ -31,7 +31,10 @@ from Backend.fastapi.routes.api_routes import (
     delete_custom_catalog_api, get_custom_catalog_items_api, search_catalog_media_api,
     add_custom_catalog_item_api, remove_custom_catalog_item_api,
     auto_sync_custom_catalogs_api, auto_catalog_sync_status_api,
-    get_auto_catalog_settings_api, update_auto_catalog_settings_api
+    get_auto_catalog_settings_api, update_auto_catalog_settings_api,
+    list_unmatched_media_api, search_unmatched_media_api,
+    apply_unmatched_media_api, reprocess_unmatched_media_api,
+    dismiss_unmatched_media_api
 )
 
 templates = Jinja2Templates(directory="Backend/fastapi/templates")
@@ -109,6 +112,11 @@ async def media_management(request: Request, media_type: str = "movie", _: bool 
 async def custom_catalogs(request: Request, _: bool = Depends(require_auth)):
     return await custom_catalogs_page(request, _)
 
+
+@app.get("/unmatched", response_class=HTMLResponse)
+async def unmatched_media(request: Request, _: bool = Depends(require_auth)):
+    return await unmatched_media_page(request, _)
+
 @app.get("/media/edit", response_class=HTMLResponse)
 async def edit_media(request: Request, tmdb_id: int, db_index: int, media_type: str, _: bool = Depends(require_auth)):
     return await edit_media_page(request, tmdb_id, db_index, media_type, _)
@@ -146,6 +154,32 @@ async def delete_tv_episode(tmdb_id: int, db_index: int, season: int, episode: i
 @app.delete("/api/media/delete-tv-season")
 async def delete_tv_season(tmdb_id: int, db_index: int, season: int, _: bool = Depends(require_auth)):
     return await delete_tv_season_api(tmdb_id, db_index, season)
+
+
+@app.get("/api/unmatched-media")
+async def list_unmatched_media(status: str = "open", _: bool = Depends(require_auth)):
+    return await list_unmatched_media_api(status)
+
+
+@app.post("/api/unmatched-media/{unmatched_id}/search")
+async def search_unmatched_media(unmatched_id: str, payload: dict, _: bool = Depends(require_auth)):
+    return await search_unmatched_media_api(unmatched_id, payload)
+
+
+@app.post("/api/unmatched-media/{unmatched_id}/apply")
+async def apply_unmatched_media(unmatched_id: str, payload: dict, _: bool = Depends(require_auth)):
+    return await apply_unmatched_media_api(unmatched_id, payload)
+
+
+@app.post("/api/unmatched-media/{unmatched_id}/reprocess")
+async def reprocess_unmatched_media(unmatched_id: str, _: bool = Depends(require_auth)):
+    return await reprocess_unmatched_media_api(unmatched_id)
+
+
+@app.post("/api/unmatched-media/{unmatched_id}/dismiss")
+async def dismiss_unmatched_media(unmatched_id: str, _: bool = Depends(require_auth)):
+    return await dismiss_unmatched_media_api(unmatched_id)
+
 
 @app.get("/api/system/workloads")
 async def get_workloads(_: bool = Depends(require_auth)):

--- a/Backend/fastapi/routes/api_routes.py
+++ b/Backend/fastapi/routes/api_routes.py
@@ -6,11 +6,13 @@ from Backend import db, StartTime, __version__
 from Backend.logger import LOGGER
 from Backend.helper.pyro import get_readable_time
 from Backend.helper.metadata import (
+    metadata,
     search_movie_candidates,
     search_tv_candidates,
     fetch_selected_movie_metadata,
     fetch_selected_tv_metadata,
 )
+from Backend.helper.pyro import clean_filename, remove_urls
 from Backend.pyrofork.bot import multi_clients, StreamBot
 from Backend.helper.custom_dl import run_speed_test, _speed_test_single_client
 from time import time
@@ -796,6 +798,90 @@ async def apply_media_rescan_api(request: Request, tmdb_id: int, db_index: int, 
         "media_type": media_type,
         "data": updated_doc,
 }
+
+
+# --- Unmatched Media Repair APIs ---
+
+async def list_unmatched_media_api(status: str = "open") -> dict:
+    items = await db.list_unmatched_media(status=status)
+    return {"status": "success", "data": items}
+
+
+async def search_unmatched_media_api(unmatched_id: str, payload: dict) -> dict:
+    item = await db.get_unmatched_media(unmatched_id)
+    if not item:
+        raise HTTPException(status_code=404, detail="Unmatched item not found")
+
+    query = (payload.get("query") or item.get("title") or item.get("file_name") or "").strip()
+    media_type = payload.get("media_type") or "movie"
+    year = payload.get("year")
+    if not query:
+        raise HTTPException(status_code=400, detail="query is required")
+
+    suggestions = (
+        await search_tv_candidates(query=query)
+        if media_type in {"tv", "series"}
+        else await search_movie_candidates(query=query, year=year)
+    )
+    await db.update_unmatched_suggestions(unmatched_id, suggestions)
+    return {"status": "success", "data": suggestions}
+
+
+async def _index_unmatched_item(item: dict, override_id: str | None = None) -> dict:
+    channel = int(item.get("channel") or str(item.get("origin_chat_id", "")).replace("-100", ""))
+    msg_id = int(item["origin_msg_id"])
+    title = item.get("title") or item.get("file_name") or "unknown"
+    display_name = remove_urls(title)
+    if not display_name.endswith((".mkv", ".mp4")):
+        display_name += ".mkv"
+
+    metadata_info = await metadata(
+        clean_filename(title),
+        channel,
+        msg_id,
+        override_id=override_id or item.get("override_id"),
+    )
+    if metadata_info is None:
+        raise HTTPException(status_code=422, detail="Metadata still could not be resolved.")
+
+    updated_id = await db.insert_media(
+        metadata_info,
+        channel=channel,
+        msg_id=msg_id,
+        size=item.get("size") or "",
+        name=display_name,
+    )
+    if not updated_id:
+        raise HTTPException(status_code=500, detail="Database insert failed")
+    return {"updated_id": updated_id, "metadata": metadata_info}
+
+
+async def apply_unmatched_media_api(unmatched_id: str, payload: dict) -> dict:
+    item = await db.get_unmatched_media(unmatched_id)
+    if not item:
+        raise HTTPException(status_code=404, detail="Unmatched item not found")
+    selected_id = (payload.get("selected_id") or "").strip()
+    if not selected_id:
+        raise HTTPException(status_code=400, detail="selected_id is required")
+    result = await _index_unmatched_item(item, override_id=selected_id)
+    await db.mark_unmatched_status(unmatched_id, "resolved", {"resolved_by": "manual_apply"})
+    return {"status": "success", **result}
+
+
+async def reprocess_unmatched_media_api(unmatched_id: str) -> dict:
+    item = await db.get_unmatched_media(unmatched_id)
+    if not item:
+        raise HTTPException(status_code=404, detail="Unmatched item not found")
+    result = await _index_unmatched_item(item, override_id=item.get("override_id"))
+    await db.mark_unmatched_status(unmatched_id, "resolved", {"resolved_by": "reprocess"})
+    return {"status": "success", **result}
+
+
+async def dismiss_unmatched_media_api(unmatched_id: str) -> dict:
+    ok = await db.mark_unmatched_status(unmatched_id, "dismissed")
+    if not ok:
+        raise HTTPException(status_code=404, detail="Unmatched item not found")
+    return {"status": "success", "message": "Unmatched item dismissed"}
 
 
 # --- Custom Catalog APIs ---

--- a/Backend/fastapi/routes/template_routes.py
+++ b/Backend/fastapi/routes/template_routes.py
@@ -281,3 +281,17 @@ async def custom_catalogs_page(request: Request, _: bool = Depends(require_auth)
         "current_theme": theme_name,
         "current_user": current_user,
     })
+
+
+async def unmatched_media_page(request: Request, _: bool = Depends(require_auth)):
+    theme_name = request.session.get("theme", "dark_professional")
+    theme = get_theme(theme_name)
+    current_user = get_current_user(request)
+
+    return templates.TemplateResponse("unmatched_media.html", {
+        "request": request,
+        "theme": theme,
+        "themes": get_all_themes(),
+        "current_theme": theme_name,
+        "current_user": current_user,
+    })

--- a/Backend/fastapi/templates/base.html
+++ b/Backend/fastapi/templates/base.html
@@ -198,6 +198,7 @@ tailwind.config = {
         <a href="/" class="nav-link">Home</a>
         <a href="/media/manage" class="nav-link">Media</a>
         <a href="/catalogs" class="nav-link">Catalogs</a>
+        <a href="/unmatched" class="nav-link">Unmatched</a>
         <a href="/admin/dashboard" class="nav-link">Admin</a>
         <a href="/admin/subscriptions" class="nav-link">Subs</a>
         <a href="/admin/access" class="nav-link">Access</a>
@@ -251,6 +252,7 @@ tailwind.config = {
             <a href="/" class="px-4 py-3 rounded-xl hover:bg-primary hover:text-background transition flex items-center gap-3 font-semibold"><i class="fa-solid fa-house"></i> Home</a>
             <a href="/media/manage" class="px-4 py-3 rounded-xl hover:bg-primary hover:text-background transition flex items-center gap-3 font-semibold"><i class="fa-solid fa-clapperboard"></i> Media</a>
             <a href="/catalogs" class="px-4 py-3 rounded-xl hover:bg-primary hover:text-background transition flex items-center gap-3 font-semibold"><i class="fa-solid fa-layer-group"></i> Catalogs</a>
+            <a href="/unmatched" class="px-4 py-3 rounded-xl hover:bg-primary hover:text-background transition flex items-center gap-3 font-semibold"><i class="fa-solid fa-triangle-exclamation"></i> Unmatched</a>
             <a href="/admin/dashboard" class="px-4 py-3 rounded-xl hover:bg-primary hover:text-background transition flex items-center gap-3 font-semibold"><i class="fa-solid fa-chart-line"></i> Admin</a>
             <a href="/admin/subscriptions" class="px-4 py-3 rounded-xl hover:bg-primary hover:text-background transition flex items-center gap-3 font-semibold"><i class="fa-solid fa-credit-card"></i> Subs</a>
             <a href="/admin/access" class="px-4 py-3 rounded-xl hover:bg-primary hover:text-background transition flex items-center gap-3 font-semibold"><i class="fa-solid fa-shield"></i> Access</a>

--- a/Backend/fastapi/templates/unmatched_media.html
+++ b/Backend/fastapi/templates/unmatched_media.html
@@ -1,0 +1,171 @@
+{% extends "base.html" %}
+
+{% block title %}Unmatched Media - TG Stremio{% endblock %}
+
+{% block content %}
+<div class="space-y-6">
+  <section class="glass-card rounded-3xl p-5 sm:p-6 lg:p-8">
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+      <div>
+        <h1 class="section-title text-2xl sm:text-3xl">Unmatched Media</h1>
+        <p class="muted mt-2">Repair uploads that could not be matched to metadata during ingestion.</p>
+      </div>
+      <div class="flex gap-2">
+        <select id="status-filter" class="theme-select" onchange="loadItems()">
+          <option value="open">Open</option>
+          <option value="resolved">Resolved</option>
+          <option value="dismissed">Dismissed</option>
+          <option value="all">All</option>
+        </select>
+        <button onclick="loadItems()" class="btn-ui btn-primary">Refresh</button>
+      </div>
+    </div>
+  </section>
+
+  <section id="items" class="space-y-4"></section>
+</div>
+
+<script>
+const state = { items: [], suggestions: {} };
+
+function escapeHtml(value) {
+  return String(value ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'}[c]));
+}
+
+function badge(text) {
+  return `<span class="pill">${escapeHtml(text)}</span>`;
+}
+
+async function loadItems() {
+  const status = document.getElementById('status-filter').value;
+  const wrap = document.getElementById('items');
+  wrap.innerHTML = '<div class="glass-card rounded-3xl p-8 text-center muted">Loading...</div>';
+  const res = await fetch(`/api/unmatched-media?status=${encodeURIComponent(status)}`);
+  const data = await res.json();
+  state.items = data.data || [];
+  if (!state.items.length) {
+    wrap.innerHTML = '<div class="glass-card rounded-3xl p-8 text-center muted">No unmatched media in this view.</div>';
+    return;
+  }
+  wrap.innerHTML = state.items.map(renderItem).join('');
+}
+
+function renderItem(item) {
+  const id = item._id;
+  const suggestions = state.suggestions[id] || item.suggestions || [];
+  return `
+    <article class="glass-card rounded-3xl p-5 sm:p-6">
+      <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
+        <div class="min-w-0">
+          <div class="flex flex-wrap gap-2 mb-3">
+            ${badge(item.source_type || 'telegram')}
+            ${badge(item.status || 'open')}
+            ${item.size ? badge(item.size) : ''}
+          </div>
+          <h2 class="font-bold text-lg break-all">${escapeHtml(item.title || item.file_name || 'Unknown')}</h2>
+          <p class="muted text-sm mt-2 break-all">${escapeHtml(item.failure_reason || 'metadata_failed')}</p>
+          ${item.parsed_title || item.parsed_year || item.match_confidence ? `
+            <div class="mt-3 grid grid-cols-1 sm:grid-cols-3 gap-2 text-xs">
+              <div class="glass-card-soft rounded-2xl p-3"><div class="muted">Parsed</div><div class="font-semibold break-all">${escapeHtml(item.parsed_title || '-')}</div></div>
+              <div class="glass-card-soft rounded-2xl p-3"><div class="muted">Year / Type</div><div class="font-semibold">${escapeHtml(item.parsed_year || '-')} · ${escapeHtml(item.parsed_media_type || '-')}</div></div>
+              <div class="glass-card-soft rounded-2xl p-3"><div class="muted">Confidence</div><div class="font-semibold">${escapeHtml(item.match_confidence ?? '-')}</div></div>
+            </div>
+            ${item.search_variants?.length ? `<p class="muted text-xs mt-2 break-all">Tried: ${escapeHtml(item.search_variants.join(' · '))}</p>` : ''}
+          ` : ''}
+          <p class="muted text-xs mt-2">Chat ${escapeHtml(item.origin_chat_id)} / message ${escapeHtml(item.origin_msg_id)}</p>
+        </div>
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-2 w-full lg:w-auto">
+          <button class="btn-ui btn-info" onclick="searchItem('${id}', 'movie')">Search Movie</button>
+          <button class="btn-ui btn-info" onclick="searchItem('${id}', 'tv')">Search TV</button>
+          <button class="btn-ui btn-primary" onclick="reprocessItem('${id}')">Reprocess</button>
+        </div>
+      </div>
+
+      <div class="mt-5">
+        ${suggestions.length ? renderSuggestions(id, suggestions) : '<p class="muted text-sm">No suggestions loaded.</p>'}
+      </div>
+
+      <div class="mt-5 flex justify-end">
+        <button class="btn-ui btn-danger" onclick="dismissItem('${id}')">Dismiss</button>
+      </div>
+    </article>
+  `;
+}
+
+function renderSuggestions(id, suggestions) {
+  return `
+    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-3">
+      ${suggestions.map(s => `
+        <div class="glass-card-soft rounded-2xl p-4 border border-white/10">
+          <div class="font-semibold">${escapeHtml(s.title || 'Unknown')}</div>
+          <div class="muted text-xs mt-1">
+            ${escapeHtml(s.subtitle || s.source || '')}
+            ${s.year ? ' · ' + escapeHtml(s.year) : ''}
+            ${s.score ? ' · score ' + escapeHtml(s.score) : ''}
+          </div>
+          <div class="muted text-[11px] mt-2 break-all">
+            ${s.imdb_id ? 'IMDb ' + escapeHtml(s.imdb_id) + ' ' : ''}
+            ${s.tmdb_id ? 'TMDb ' + escapeHtml(s.tmdb_id) : ''}
+            ${s.reason ? '<br>Reason: ' + escapeHtml(s.reason) : ''}
+          </div>
+          <button class="btn-ui btn-success w-full mt-3" onclick="applyItem('${id}', '${escapeHtml(s.tmdb_id || s.imdb_id || '')}')">Apply</button>
+        </div>
+      `).join('')}
+    </div>
+  `;
+}
+
+async function searchItem(id, mediaType) {
+  const item = state.items.find(i => i._id === id);
+  const query = prompt('Search title', item?.title || item?.file_name || '');
+  if (!query) return;
+  const res = await fetch(`/api/unmatched-media/${id}/search`, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({query, media_type: mediaType})
+  });
+  const data = await res.json();
+  state.suggestions[id] = data.data || [];
+  renderAll();
+}
+
+async function applyItem(id, selectedId) {
+  if (!selectedId) return;
+  if (!confirm(`Apply metadata ${selectedId} to this item?`)) return;
+  const res = await fetch(`/api/unmatched-media/${id}/apply`, {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({selected_id: selectedId})
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    alert(err.detail || 'Apply failed');
+    return;
+  }
+  await loadItems();
+}
+
+async function reprocessItem(id) {
+  if (!confirm('Reprocess this item using its current filename/caption?')) return;
+  const res = await fetch(`/api/unmatched-media/${id}/reprocess`, {method: 'POST'});
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    alert(err.detail || 'Reprocess failed');
+    return;
+  }
+  await loadItems();
+}
+
+async function dismissItem(id) {
+  if (!confirm('Dismiss this unmatched item?')) return;
+  await fetch(`/api/unmatched-media/${id}/dismiss`, {method: 'POST'});
+  await loadItems();
+}
+
+function renderAll() {
+  document.getElementById('items').innerHTML = state.items.map(renderItem).join('');
+}
+
+loadItems();
+</script>
+{% endblock %}

--- a/Backend/helper/database.py
+++ b/Backend/helper/database.py
@@ -5,7 +5,7 @@ from bson import ObjectId
 import motor.motor_asyncio
 from datetime import datetime, timezone
 from pydantic import ValidationError
-from pymongo import ASCENDING, DESCENDING
+from pymongo import ASCENDING, DESCENDING, ReturnDocument
 from typing import Dict, List, Optional, Tuple, Any
 
 from Backend.logger import LOGGER
@@ -1640,6 +1640,67 @@ class Database:
             return {"summary": {}, "per_client": [], "recent": []}
 
 
+
+    # -------------------------------
+    # Unmatched Media Repair Queue
+    # -------------------------------
+
+    async def upsert_unmatched_media(self, job: dict, reason: str, suggestions: Optional[List[dict]] = None) -> str:
+        """Store a metadata-failed Telegram item for manual repair."""
+        now = datetime.utcnow()
+        source_key = job.get("source_key") or f"{job.get('source_type', 'telegram')}:{job.get('chat_id')}:{job.get('msg_id')}"
+        doc = {
+            "source_key": source_key,
+            "source_type": job.get("source_type", "telegram"),
+            "origin_chat_id": job.get("chat_id"),
+            "origin_msg_id": job.get("msg_id"),
+            "channel": job.get("channel"),
+            "title": job.get("title") or job.get("file_name") or "",
+            "file_name": job.get("file_name") or job.get("title") or "",
+            "size": job.get("size"),
+            "file_size": job.get("file_size"),
+            "override_id": job.get("override_id"),
+            "failure_reason": str(reason or "metadata_failed")[:500],
+            "suggestions": suggestions or [],
+            "status": "open",
+            "updated_at": now,
+        }
+        result = await self.dbs["tracking"]["unmatched_media"].find_one_and_update(
+            {"source_key": source_key},
+            {"$set": doc, "$setOnInsert": {"created_at": now}},
+            upsert=True,
+            return_document=ReturnDocument.AFTER,
+        )
+        return str(result["_id"])
+
+    async def get_unmatched_media(self, unmatched_id: str) -> Optional[dict]:
+        try:
+            doc = await self.dbs["tracking"]["unmatched_media"].find_one({"_id": ObjectId(unmatched_id)})
+            return convert_objectid_to_str(doc) if doc else None
+        except Exception:
+            return None
+
+    async def list_unmatched_media(self, status: str = "open", limit: int = 100) -> List[dict]:
+        query = {} if status == "all" else {"status": status}
+        docs = await self.dbs["tracking"]["unmatched_media"].find(query).sort("updated_at", DESCENDING).limit(limit).to_list(None)
+        return [convert_objectid_to_str(doc) for doc in docs]
+
+    async def update_unmatched_suggestions(self, unmatched_id: str, suggestions: List[dict]) -> bool:
+        result = await self.dbs["tracking"]["unmatched_media"].update_one(
+            {"_id": ObjectId(unmatched_id)},
+            {"$set": {"suggestions": suggestions, "updated_at": datetime.utcnow()}},
+        )
+        return result.modified_count > 0
+
+    async def mark_unmatched_status(self, unmatched_id: str, status: str, extra: Optional[dict] = None) -> bool:
+        update = {"status": status, "updated_at": datetime.utcnow()}
+        if extra:
+            update.update(extra)
+        result = await self.dbs["tracking"]["unmatched_media"].update_one(
+            {"_id": ObjectId(unmatched_id)},
+            {"$set": update},
+        )
+        return result.modified_count > 0
 
     async def replace_media_metadata(
         self,

--- a/Backend/pyrofork/plugins/reciever.py
+++ b/Backend/pyrofork/plugins/reciever.py
@@ -46,6 +46,19 @@ async def file_receive_handler(client: Client, message: Message):
 
                 metadata_info = await metadata(clean_filename(title), int(channel), msg_id)
                 if metadata_info is None:
+                    await db.upsert_unmatched_media(
+                        {
+                            "source_type": "telegram",
+                            "chat_id": int(message.chat.id),
+                            "channel": int(channel),
+                            "msg_id": msg_id,
+                            "title": title,
+                            "file_name": file.file_name,
+                            "size": size,
+                            "file_size": file.file_size,
+                        },
+                        "metadata_failed",
+                    )
                     LOGGER.warning(f"Metadata failed for file: {title} (ID: {msg_id})")
                     return
 
@@ -98,6 +111,20 @@ async def file_edited_handler(client: Client, message: Message):
 
                     metadata_info = await metadata(clean_filename(title), int(channel), msg_id, override_id=override_id)
                     if metadata_info is None:
+                        await db.upsert_unmatched_media(
+                            {
+                                "source_type": "telegram",
+                                "chat_id": int(message.chat.id),
+                                "channel": int(channel),
+                                "msg_id": msg_id,
+                                "title": title,
+                                "file_name": file.file_name,
+                                "size": size,
+                                "file_size": file.file_size,
+                                "override_id": override_id,
+                            },
+                            "metadata_failed",
+                        )
                         LOGGER.warning(f"Metadata failed for edited file: {title} (ID: {msg_id})")
                         return
 

--- a/Backend/pyrofork/plugins/scanner.py
+++ b/Backend/pyrofork/plugins/scanner.py
@@ -216,6 +216,19 @@ async def _scan_channel(client: Client, chat_id: int):
                 metadata_info = None
 
             if metadata_info is None:
+                await db.upsert_unmatched_media(
+                    {
+                        "source_type": "telegram",
+                        "chat_id": int(chat_id),
+                        "channel": channel_int,
+                        "msg_id": msg_id,
+                        "title": title,
+                        "file_name": getattr(file, "file_name", None),
+                        "size": size,
+                        "file_size": getattr(file, "file_size", None),
+                    },
+                    "metadata_failed",
+                )
                 s.skipped_meta += 1
                 s.processed += 1
                 await _update_progress()

--- a/tests/test_unmatched_media.py
+++ b/tests/test_unmatched_media.py
@@ -1,0 +1,105 @@
+import os
+
+os.environ.setdefault(
+    "DATABASE",
+    "mongodb://localhost:27017/unmatched_tracking,mongodb://localhost:27017/unmatched_storage",
+)
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from Backend.fastapi.routes import api_routes
+
+
+class UnmatchedMediaApiTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.fake_db = SimpleNamespace(
+            list_unmatched_media=AsyncMock(),
+            get_unmatched_media=AsyncMock(),
+            update_unmatched_suggestions=AsyncMock(return_value=True),
+            mark_unmatched_status=AsyncMock(return_value=True),
+            insert_media=AsyncMock(return_value="media_123"),
+        )
+        self.db_patch = patch.object(api_routes, "db", self.fake_db)
+        self.db_patch.start()
+
+    async def asyncTearDown(self):
+        self.db_patch.stop()
+
+    async def test_list_unmatched_media_api_returns_items(self):
+        self.fake_db.list_unmatched_media.return_value = [{"_id": "1", "title": "Example"}]
+
+        result = await api_routes.list_unmatched_media_api()
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["data"][0]["title"], "Example")
+        self.fake_db.list_unmatched_media.assert_awaited_once_with(status="open")
+
+    async def test_search_unmatched_media_api_stores_suggestions(self):
+        self.fake_db.get_unmatched_media.return_value = {
+            "_id": "1",
+            "title": "Example Movie",
+            "file_name": "Example.Movie.2024.mkv",
+        }
+
+        with patch.object(api_routes, "search_movie_candidates", AsyncMock(return_value=[{"title": "Example Movie"}])):
+            result = await api_routes.search_unmatched_media_api(
+                "1",
+                {"query": "Example Movie", "media_type": "movie", "year": 2024},
+            )
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["data"][0]["title"], "Example Movie")
+        self.fake_db.update_unmatched_suggestions.assert_awaited_once()
+
+    async def test_apply_unmatched_media_api_indexes_selected_title(self):
+        self.fake_db.get_unmatched_media.return_value = {
+            "_id": "1",
+            "title": "Example Movie 2024",
+            "file_name": "Example.Movie.2024.mkv",
+            "origin_chat_id": -1001234567890,
+            "origin_msg_id": 42,
+        }
+
+        with (
+            patch.object(api_routes, "clean_filename", lambda value: value),
+            patch.object(api_routes, "remove_urls", lambda value: value),
+            patch.object(api_routes, "metadata", AsyncMock(return_value={"tmdb_id": 999})),
+        ):
+            result = await api_routes.apply_unmatched_media_api("1", {"selected_id": "tt9999999"})
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["updated_id"], "media_123")
+        self.fake_db.insert_media.assert_awaited_once()
+        self.fake_db.mark_unmatched_status.assert_awaited_once_with("1", "resolved", {"resolved_by": "manual_apply"})
+
+    async def test_reprocess_unmatched_media_api_marks_resolved(self):
+        self.fake_db.get_unmatched_media.return_value = {
+            "_id": "1",
+            "title": "Example Movie 2024",
+            "file_name": "Example.Movie.2024.mkv",
+            "origin_chat_id": -1001234567890,
+            "origin_msg_id": 42,
+        }
+
+        with (
+            patch.object(api_routes, "clean_filename", lambda value: value),
+            patch.object(api_routes, "remove_urls", lambda value: value),
+            patch.object(api_routes, "metadata", AsyncMock(return_value={"tmdb_id": 999})),
+        ):
+            result = await api_routes.reprocess_unmatched_media_api("1")
+
+        self.assertEqual(result["status"], "success")
+        self.fake_db.mark_unmatched_status.assert_awaited_once_with("1", "resolved", {"resolved_by": "reprocess"})
+
+    async def test_dismiss_unmatched_media_api(self):
+        result = await api_routes.dismiss_unmatched_media_api("1")
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["message"], "Unmatched item dismissed")
+        self.fake_db.mark_unmatched_status.assert_awaited_once_with("1", "dismissed")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR keeps unmatched-media handling separate from the metadata matcher change.

What it adds:
- Stores Telegram uploads that fail metadata lookup in an unmatched_media queue
- Adds a protected /unmatched admin page
- Adds search / apply / reprocess / dismiss APIs for manual repair
- Records failed Telegram-only items without changing stream behavior

What it does not change:
- Torrent repair flows
- Native torrent streaming
- Existing Telegram stream playback
- Catalog or dashboard behavior outside unmatched-media visibility

Tests:
- python -m compileall Backend tests
- python -m unittest -v tests.test_unmatched_media
- python -c "import tempfile, unittest; tempfile.tempdir=r'C:\\tmp'; suite=unittest.defaultTestLoader.discover('tests'); result=unittest.TextTestRunner(verbosity=2).run(suite); raise SystemExit(0 if result.wasSuccessful() else 1)"