### PR TITLE
Add manual stream quality controls

### DIFF
--- a/Backend/fastapi/main.py
+++ b/Backend/fastapi/main.py
@@ -27,6 +27,7 @@ from Backend.fastapi.routes.api_routes import (
     get_all_subscribers_api, manage_subscriber_api,
     get_all_tokens_api, assign_plan_api, link_token_user_api,
     search_media_rescan_api, apply_media_rescan_api,
+    get_duplicate_media_api, update_quality_flags_api, clear_quality_flags_api,
     list_custom_catalogs_api, create_custom_catalog_api, update_custom_catalog_api,
     delete_custom_catalog_api, get_custom_catalog_items_api, search_catalog_media_api,
     add_custom_catalog_item_api, remove_custom_catalog_item_api,
@@ -146,6 +147,18 @@ async def delete_tv_episode(tmdb_id: int, db_index: int, season: int, episode: i
 @app.delete("/api/media/delete-tv-season")
 async def delete_tv_season(tmdb_id: int, db_index: int, season: int, _: bool = Depends(require_auth)):
     return await delete_tv_season_api(tmdb_id, db_index, season)
+
+@app.get("/api/media/duplicates")
+async def get_media_duplicates(_: bool = Depends(require_auth)):
+    return await get_duplicate_media_api()
+
+@app.post("/api/media/quality-flags")
+async def update_quality_flags(payload: dict, _: bool = Depends(require_auth)):
+    return await update_quality_flags_api(payload)
+
+@app.post("/api/media/quality-flags/clear")
+async def clear_quality_flags(payload: dict, _: bool = Depends(require_auth)):
+    return await clear_quality_flags_api(payload)
 
 @app.get("/api/system/workloads")
 async def get_workloads(_: bool = Depends(require_auth)):

--- a/Backend/fastapi/routes/api_routes.py
+++ b/Backend/fastapi/routes/api_routes.py
@@ -795,7 +795,51 @@ async def apply_media_rescan_api(request: Request, tmdb_id: int, db_index: int, 
         "db_index": updated_doc.get("db_index", db_index),
         "media_type": media_type,
         "data": updated_doc,
-}
+    }
+
+
+# --- Duplicate / Quality Flag APIs ---
+
+async def get_duplicate_media_api() -> dict:
+    groups = await db.get_duplicate_quality_groups()
+    return {"status": "success", "data": groups}
+
+
+async def update_quality_flags_api(payload: dict) -> dict:
+    flags = payload.get("flags") or {
+        key: payload[key]
+        for key in ("hidden_from_stremio", "recommended", "quality_note", "flagged_duplicate")
+        if key in payload
+    }
+    ok = await db.update_quality_flags(
+        media_type=payload.get("media_type"),
+        tmdb_id=int(payload.get("tmdb_id")),
+        db_index=int(payload.get("db_index")),
+        quality_id=payload.get("id") or payload.get("quality_id"),
+        flags=flags,
+        season=payload.get("season"),
+        episode=payload.get("episode"),
+        clear=False,
+    )
+    if not ok:
+        raise HTTPException(status_code=404, detail="Quality not found")
+    return {"status": "success", "message": "Quality flags updated"}
+
+
+async def clear_quality_flags_api(payload: dict) -> dict:
+    ok = await db.update_quality_flags(
+        media_type=payload.get("media_type"),
+        tmdb_id=int(payload.get("tmdb_id")),
+        db_index=int(payload.get("db_index")),
+        quality_id=payload.get("id") or payload.get("quality_id"),
+        flags={},
+        season=payload.get("season"),
+        episode=payload.get("episode"),
+        clear=True,
+    )
+    if not ok:
+        raise HTTPException(status_code=404, detail="Quality not found")
+    return {"status": "success", "message": "Quality flags cleared"}
 
 
 # --- Custom Catalog APIs ---

--- a/Backend/fastapi/routes/stremio_routes.py
+++ b/Backend/fastapi/routes/stremio_routes.py
@@ -594,6 +594,8 @@ async def get_streams(
 
     streams = []
     for quality in media_details.get("telegram", []):
+        if quality.get("hidden_from_stremio"):
+            continue
         if quality.get("id"):
             filename = quality.get("name", "")
             quality_str = quality.get("quality", "HD")
@@ -602,6 +604,15 @@ async def get_streams(
             stream_name, stream_title = format_stream_details(
                 filename, quality_str, size
             )
+            badges = []
+            if quality.get("recommended"):
+                badges.append("⭐ Recommended")
+            if quality.get("flagged_duplicate"):
+                badges.append("⚠️ Duplicate")
+            if quality.get("quality_note"):
+                badges.append(str(quality.get("quality_note"))[:80])
+            if badges:
+                stream_title = f"{' | '.join(badges)}\n{stream_title}"
 
             original_url = f"{BASE_URL}/dl/{token}/{quality.get('id')}/video.mkv"
             proxy_url = f"{Telegram.HTTP_PROXY_URL}{original_url}" if Telegram.PROXY and Telegram.HTTP_PROXY_URL else None
@@ -610,30 +621,39 @@ async def get_streams(
                 streams.append({
                     "name": f"{stream_name} (Proxy)",
                     "title": stream_title,
-                    "url": proxy_url
+                    "url": proxy_url,
+                    "_recommended": bool(quality.get("recommended")),
                 })
                 streams.append({
                     "name": f"{stream_name} (Direct)",
                     "title": stream_title,
-                    "url": original_url
+                    "url": original_url,
+                    "_recommended": bool(quality.get("recommended")),
                 })
             elif proxy_url:
                 streams.append({
                     "name": stream_name,
                     "title": stream_title,
-                    "url": proxy_url
+                    "url": proxy_url,
+                    "_recommended": bool(quality.get("recommended")),
                 })
             else:
                 streams.append({
                     "name": stream_name,
                     "title": stream_title,
-                    "url": original_url
+                    "url": original_url,
+                    "_recommended": bool(quality.get("recommended")),
                 })
 
     streams.sort(
-        key=lambda s: get_resolution_priority(s.get("name", "")),
+        key=lambda s: (
+            1 if s.get("_recommended") else 0,
+            get_resolution_priority(s.get("name", "")),
+        ),
         reverse=True
     )
+    for stream in streams:
+        stream.pop("_recommended", None)
 
     # Deduplicate stream names — Stremio collapses streams with identical names,
     # so when two files share the same caption we append (1), (2) ... to each duplicate.

--- a/Backend/fastapi/templates/media_edit.html
+++ b/Backend/fastapi/templates/media_edit.html
@@ -482,11 +482,15 @@
                                 {{ quality.quality }}
                             </span>
                             <span class="pill">{{ quality.size }}</span>
+                            {% if quality.recommended %}<span class="pill bg-green-500/15 text-green-300 border border-green-500/20">Recommended</span>{% endif %}
+                            {% if quality.hidden_from_stremio %}<span class="pill bg-red-500/15 text-red-300 border border-red-500/20">Hidden</span>{% endif %}
+                            {% if quality.flagged_duplicate %}<span class="pill bg-yellow-500/15 text-yellow-300 border border-yellow-500/20">Duplicate</span>{% endif %}
                         </div>
                         <p class="muted mt-3 text-sm break-all">{{ quality.name }}</p>
+                        {% if quality.quality_note %}<p class="muted mt-2 text-xs">Note: {{ quality.quality_note }}</p>{% endif %}
                     </div>
 
-                    <div class="grid grid-cols-1 sm:grid-cols-3 gap-2 w-full sm:w-auto xl:min-w-[24rem]">
+                    <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-2 w-full sm:w-auto xl:min-w-[34rem]">
                         <button onclick="copyStreamLink('{{ quality.id }}', '{{ quality.name }}')" class="btn-ui btn-success w-full" title="Copy direct stream link">
                             📋 Copy Link
                         </button>
@@ -495,6 +499,18 @@
                         </button>
                         <button onclick="deleteQuality('{{ quality.id }}')" class="btn-ui btn-danger w-full">
                             Delete
+                        </button>
+                        <button onclick="setQualityFlags('{{ quality.id }}', {recommended: {{ 'false' if quality.recommended else 'true' }}})" class="btn-ui btn-primary w-full">
+                            {{ 'Unrecommend' if quality.recommended else 'Recommend' }}
+                        </button>
+                        <button onclick="setQualityFlags('{{ quality.id }}', {hidden_from_stremio: {{ 'false' if quality.hidden_from_stremio else 'true' }}})" class="btn-ui btn-ghost w-full">
+                            {{ 'Show' if quality.hidden_from_stremio else 'Hide' }}
+                        </button>
+                        <button onclick="setQualityNote('{{ quality.id }}')" class="btn-ui btn-info w-full">
+                            Note
+                        </button>
+                        <button onclick="setQualityFlags('{{ quality.id }}', {flagged_duplicate: {{ 'false' if quality.flagged_duplicate else 'true' }}})" class="btn-ui btn-ghost w-full">
+                            {{ 'Unflag Dup' if quality.flagged_duplicate else 'Flag Dup' }}
                         </button>
                     </div>
                 </div>
@@ -548,11 +564,15 @@
                                                     <div class="flex flex-wrap items-center gap-2 sm:gap-3">
                                                         <span class="quality-badge bg-green-500/15 text-green-300 border border-green-500/20">{{ quality.quality }}</span>
                                                         <span class="pill">{{ quality.size }}</span>
+                                                        {% if quality.recommended %}<span class="pill bg-green-500/15 text-green-300 border border-green-500/20">Recommended</span>{% endif %}
+                                                        {% if quality.hidden_from_stremio %}<span class="pill bg-red-500/15 text-red-300 border border-red-500/20">Hidden</span>{% endif %}
+                                                        {% if quality.flagged_duplicate %}<span class="pill bg-yellow-500/15 text-yellow-300 border border-yellow-500/20">Duplicate</span>{% endif %}
                                                     </div>
                                                     <p class="muted text-xs sm:text-sm mt-2 break-all">{{ quality.name }}</p>
+                                                    {% if quality.quality_note %}<p class="muted mt-2 text-xs">Note: {{ quality.quality_note }}</p>{% endif %}
                                                 </div>
 
-                                                <div class="grid grid-cols-1 sm:grid-cols-3 gap-2 w-full sm:w-auto xl:min-w-[22rem]">
+                                                <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-2 w-full sm:w-auto xl:min-w-[34rem]">
                                                     <button onclick="copyStreamLink('{{ quality.id }}', '{{ quality.name }}')" class="btn-ui btn-success w-full text-xs sm:text-sm">
                                                         📋 Copy
                                                     </button>
@@ -561,6 +581,18 @@
                                                     </button>
                                                     <button onclick="deleteTVQuality({{ season.season_number }}, {{ episode.episode_number }}, '{{ quality.id }}')" class="btn-ui btn-danger w-full text-xs sm:text-sm">
                                                         Delete
+                                                    </button>
+                                                    <button onclick="setQualityFlags('{{ quality.id }}', {recommended: {{ 'false' if quality.recommended else 'true' }}}, {{ season.season_number }}, {{ episode.episode_number }})" class="btn-ui btn-primary w-full text-xs sm:text-sm">
+                                                        {{ 'Unrecommend' if quality.recommended else 'Recommend' }}
+                                                    </button>
+                                                    <button onclick="setQualityFlags('{{ quality.id }}', {hidden_from_stremio: {{ 'false' if quality.hidden_from_stremio else 'true' }}}, {{ season.season_number }}, {{ episode.episode_number }})" class="btn-ui btn-ghost w-full text-xs sm:text-sm">
+                                                        {{ 'Show' if quality.hidden_from_stremio else 'Hide' }}
+                                                    </button>
+                                                    <button onclick="setQualityNote('{{ quality.id }}', {{ season.season_number }}, {{ episode.episode_number }})" class="btn-ui btn-info w-full text-xs sm:text-sm">
+                                                        Note
+                                                    </button>
+                                                    <button onclick="setQualityFlags('{{ quality.id }}', {flagged_duplicate: {{ 'false' if quality.flagged_duplicate else 'true' }}}, {{ season.season_number }}, {{ episode.episode_number }})" class="btn-ui btn-ghost w-full text-xs sm:text-sm">
+                                                        {{ 'Unflag Dup' if quality.flagged_duplicate else 'Flag Dup' }}
                                                     </button>
                                                 </div>
                                             </div>
@@ -928,6 +960,42 @@
             console.error('Error deleting:', error);
             showErrorMessage('Error deleting. Please try again.');
         }
+    }
+
+    async function setQualityFlags(id, flags, season = null, episode = null) {
+        const payload = {
+            media_type: mediaType,
+            tmdb_id: tmdbId,
+            db_index: dbIndex,
+            id,
+            flags
+        };
+        if (season !== null) payload.season = season;
+        if (episode !== null) payload.episode = episode;
+
+        try {
+            const response = await fetch('/api/media/quality-flags', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+            if (response.ok) {
+                showSuccessMessage('Quality flags updated');
+                setTimeout(() => location.reload(), 700);
+            } else {
+                const error = await response.json().catch(() => ({}));
+                showErrorMessage(`Flag update failed: ${error.detail || 'Unknown error'}`);
+            }
+        } catch (error) {
+            console.error('Flag update failed:', error);
+            showErrorMessage('Flag update failed. Please try again.');
+        }
+    }
+
+    async function setQualityNote(id, season = null, episode = null) {
+        const note = prompt('Quality note, for example: bad seek, slow, duplicate, TV risky', '');
+        if (note === null) return;
+        await setQualityFlags(id, { quality_note: note }, season, episode);
     }
 
     async function deleteTVEpisode(season, episode) {

--- a/Backend/helper/database.py
+++ b/Backend/helper/database.py
@@ -1639,6 +1639,144 @@ class Database:
             LOGGER.error(f"get_stream_analytics error: {e}")
             return {"summary": {}, "per_client": [], "recent": []}
 
+    @staticmethod
+    def _apply_quality_flags(quality: dict, flags: dict, clear: bool = False) -> dict:
+        allowed = {"hidden_from_stremio", "recommended", "quality_note", "flagged_duplicate"}
+        for key in allowed:
+            if clear:
+                quality[key] = None if key == "quality_note" else False
+            elif key in flags:
+                quality[key] = (flags.get(key) or None) if key == "quality_note" else bool(flags.get(key))
+        return quality
+
+    async def update_quality_flags(
+        self,
+        media_type: str,
+        tmdb_id: int,
+        db_index: int,
+        quality_id: str,
+        flags: dict,
+        season: Optional[int] = None,
+        episode: Optional[int] = None,
+        clear: bool = False,
+    ) -> bool:
+        db_key = f"storage_{db_index}"
+        collection_name = "tv" if str(media_type).lower() in {"tv", "series"} else "movie"
+        collection = self.dbs[db_key][collection_name]
+        doc = await collection.find_one({"tmdb_id": int(tmdb_id)})
+        if not doc or not quality_id:
+            return False
+
+        found = False
+        if collection_name == "movie":
+            for quality in doc.get("telegram", []):
+                if quality.get("id") == quality_id:
+                    self._apply_quality_flags(quality, flags, clear=clear)
+                    found = True
+                    break
+        else:
+            for season_doc in doc.get("seasons", []):
+                if season is not None and int(season_doc.get("season_number", -1)) != int(season):
+                    continue
+                for episode_doc in season_doc.get("episodes", []):
+                    if episode is not None and int(episode_doc.get("episode_number", -1)) != int(episode):
+                        continue
+                    for quality in episode_doc.get("telegram", []):
+                        if quality.get("id") == quality_id:
+                            self._apply_quality_flags(quality, flags, clear=clear)
+                            found = True
+                            break
+                    if found:
+                        break
+                if found:
+                    break
+
+        if not found:
+            return False
+
+        doc["updated_on"] = datetime.utcnow()
+        result = await collection.replace_one({"_id": doc["_id"]}, doc)
+        return result.modified_count > 0 or result.matched_count > 0
+
+    @staticmethod
+    def _duplicate_key_for_quality(quality: dict) -> str:
+        if quality.get("info_hash"):
+            return f"torrent:{str(quality.get('info_hash')).lower()}:{quality.get('file_idx')}"
+        if quality.get("id"):
+            return f"id:{quality.get('id')}"
+        filename = (quality.get("filename") or quality.get("name") or "").strip().lower()
+        size = quality.get("video_size") or quality.get("size") or ""
+        return f"file:{filename}:{size}"
+
+    def _duplicate_group(
+        self,
+        doc: dict,
+        media_type: str,
+        qualities: list,
+        season: Optional[int] = None,
+        episode: Optional[int] = None,
+    ) -> Optional[dict]:
+        if len(qualities) < 2:
+            return None
+
+        buckets: Dict[str, List[dict]] = {}
+        for quality in qualities:
+            buckets.setdefault(self._duplicate_key_for_quality(quality), []).append(quality)
+        exact_duplicates = [items for items in buckets.values() if len(items) > 1]
+
+        return {
+            "media_type": media_type,
+            "tmdb_id": doc.get("tmdb_id"),
+            "db_index": doc.get("db_index"),
+            "title": doc.get("title"),
+            "season": season,
+            "episode": episode,
+            "quality_count": len(qualities),
+            "exact_duplicate_count": sum(len(items) for items in exact_duplicates),
+            "qualities": [
+                {
+                    "id": quality.get("id"),
+                    "quality": quality.get("quality"),
+                    "name": quality.get("name") or quality.get("filename"),
+                    "size": quality.get("size") or quality.get("video_size"),
+                    "hidden_from_stremio": bool(quality.get("hidden_from_stremio", False)),
+                    "recommended": bool(quality.get("recommended", False)),
+                    "quality_note": quality.get("quality_note"),
+                    "flagged_duplicate": bool(quality.get("flagged_duplicate", False)),
+                }
+                for quality in qualities
+            ],
+        }
+
+    async def get_duplicate_quality_groups(self, limit: int = 200) -> List[dict]:
+        groups: List[dict] = []
+        for index in range(1, self.current_db_index + 1):
+            db_key = f"storage_{index}"
+            movie_cursor = self.dbs[db_key]["movie"].find({"telegram.1": {"$exists": True}})
+            async for doc in movie_cursor:
+                group = self._duplicate_group(doc, "movie", doc.get("telegram", []))
+                if group:
+                    groups.append(group)
+                if len(groups) >= limit:
+                    return groups
+
+            tv_cursor = self.dbs[db_key]["tv"].find({"seasons.episodes.telegram.1": {"$exists": True}})
+            async for doc in tv_cursor:
+                for season_doc in doc.get("seasons", []):
+                    for episode_doc in season_doc.get("episodes", []):
+                        group = self._duplicate_group(
+                            doc,
+                            "tv",
+                            episode_doc.get("telegram", []),
+                            season=season_doc.get("season_number"),
+                            episode=episode_doc.get("episode_number"),
+                        )
+                        if group:
+                            groups.append(group)
+                        if len(groups) >= limit:
+                            return groups
+        return groups
+
 
 
     async def replace_media_metadata(

--- a/Backend/helper/modal.py
+++ b/Backend/helper/modal.py
@@ -10,6 +10,10 @@ class QualityDetail(BaseModel):
     id: str
     name: str
     size: str
+    hidden_from_stremio: bool = False
+    recommended: bool = False
+    quality_note: Optional[str] = None
+    flagged_duplicate: bool = False
 
 
 # ---------------------------

--- a/tests/test_quality_controls.py
+++ b/tests/test_quality_controls.py
@@ -1,0 +1,136 @@
+import os
+
+os.environ.setdefault(
+    "DATABASE",
+    "mongodb://localhost:27017/quality_tracking,mongodb://localhost:27017/quality_storage",
+)
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from Backend.fastapi.routes import api_routes, stremio_routes
+from Backend.helper.database import Database
+
+
+class QualityControlTests(unittest.IsolatedAsyncioTestCase):
+    def test_apply_quality_flags_and_clear(self):
+        quality = {"id": "q1", "quality": "1080p"}
+
+        Database._apply_quality_flags(
+            quality,
+            {
+                "recommended": True,
+                "hidden_from_stremio": True,
+                "quality_note": "bad seek",
+                "flagged_duplicate": True,
+            },
+        )
+
+        self.assertTrue(quality["recommended"])
+        self.assertTrue(quality["hidden_from_stremio"])
+        self.assertEqual(quality["quality_note"], "bad seek")
+        self.assertTrue(quality["flagged_duplicate"])
+
+        Database._apply_quality_flags(quality, {}, clear=True)
+        self.assertFalse(quality["recommended"])
+        self.assertFalse(quality["hidden_from_stremio"])
+        self.assertIsNone(quality["quality_note"])
+        self.assertFalse(quality["flagged_duplicate"])
+
+    def test_duplicate_group_lists_multiple_qualities(self):
+        database = Database()
+        doc = {
+            "tmdb_id": 123,
+            "db_index": 1,
+            "title": "Example",
+        }
+        qualities = [
+            {"id": "same", "quality": "1080p", "name": "one.mkv", "size": "1 GB"},
+            {"id": "same", "quality": "1080p", "name": "two.mkv", "size": "1 GB"},
+        ]
+
+        group = database._duplicate_group(doc, "movie", qualities)
+
+        self.assertEqual(group["quality_count"], 2)
+        self.assertEqual(group["exact_duplicate_count"], 2)
+        self.assertEqual(group["qualities"][0]["id"], "same")
+
+    async def test_quality_flags_api_forwards_admin_selection(self):
+        fake_db = SimpleNamespace(update_quality_flags=AsyncMock(return_value=True))
+        payload = {
+            "media_type": "movie",
+            "tmdb_id": 123,
+            "db_index": 1,
+            "id": "q1",
+            "flags": {"recommended": True},
+        }
+
+        with patch.object(api_routes, "db", fake_db):
+            result = await api_routes.update_quality_flags_api(payload)
+
+        self.assertEqual(result["status"], "success")
+        fake_db.update_quality_flags.assert_awaited_once_with(
+            media_type="movie",
+            tmdb_id=123,
+            db_index=1,
+            quality_id="q1",
+            flags={"recommended": True},
+            season=None,
+            episode=None,
+            clear=False,
+        )
+
+    async def test_stremio_hides_flagged_quality_and_prioritizes_recommended(self):
+        fake_db = SimpleNamespace(
+            get_media_details=AsyncMock(
+                return_value={
+                    "telegram": [
+                        {
+                            "id": "hidden",
+                            "name": "Hidden.Movie.2160p.mkv",
+                            "quality": "2160p",
+                            "size": "8 GB",
+                            "hidden_from_stremio": True,
+                        },
+                        {
+                            "id": "normal",
+                            "name": "Normal.Movie.1080p.mkv",
+                            "quality": "1080p",
+                            "size": "4 GB",
+                        },
+                        {
+                            "id": "recommended",
+                            "name": "Recommended.Movie.720p.mkv",
+                            "quality": "720p",
+                            "size": "2 GB",
+                            "recommended": True,
+                            "quality_note": "stable",
+                        },
+                    ]
+                }
+            )
+        )
+
+        with (
+            patch.object(stremio_routes, "db", fake_db),
+            patch.object(stremio_routes.Telegram, "PROXY", False),
+            patch.object(stremio_routes.Telegram, "SHOW_PROXY_AND_NON_PROXY_BOTH", False),
+        ):
+            result = await stremio_routes.get_streams(
+                token="token",
+                media_type="movie",
+                id="tt123",
+                token_data={},
+            )
+
+        urls = [stream["url"] for stream in result["streams"]]
+        self.assertEqual(len(urls), 2)
+        self.assertIn("recommended", urls[0])
+        self.assertNotIn("hidden", " ".join(urls))
+        self.assertIn("Recommended", result["streams"][0]["title"])
+        self.assertIn("stable", result["streams"][0]["title"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds manual per-quality controls without changing ingestion or streaming architecture.

What it adds:
- Mark a quality as recommended
- Hide/show a quality in Stremio
- Add an admin note such as bad seek, slow, duplicate, or TV risky
- Manually flag/unflag duplicate qualities
- Duplicate-group API for movies and TV episodes
- Recommended streams sort first; hidden streams are omitted
- Controls are available directly from the media edit page

What it does not add:
- Automatic hiding or deletion
- Torrent support
- Unmatched media repair
- Streaming reliability or dashboard changes

Tests:
- python -m compileall Backend tests
- python -m unittest -v tests.test_quality_controls
- python -c "import tempfile, unittest; tempfile.tempdir=r'C:\\tmp'; suite=unittest.defaultTestLoader.discover('tests'); result=unittest.TextTestRunner(verbosity=2).run(suite); raise SystemExit(0 if result.wasSuccessful() else 1)"