### PR TITLE
Fix: split files wrongly flagged as dead links

### DIFF
--- a/Backend/helper/database.py
+++ b/Backend/helper/database.py
@@ -1710,6 +1710,43 @@ class Database:
                 
         return False
 
+    async def clear_dead_link(self, media_type: str, tmdb_id: int, db_index: int, quality_id: str) -> bool:
+        """
+        Clears the 'is_dead' flag from a specific telegram quality entry
+        (i.e. marks a previously-flagged link as alive again).
+        """
+        db_key = f"storage_{db_index}"
+
+        if media_type == "movie":
+            result = await self.dbs[db_key]["movie"].update_one(
+                {"tmdb_id": tmdb_id, "telegram.id": quality_id},
+                {"$set": {"telegram.$.is_dead": False, "updated_on": datetime.utcnow()}}
+            )
+            return result.modified_count > 0
+
+        elif media_type == "tv":
+            tv = await self.dbs[db_key]["tv"].find_one({"tmdb_id": tmdb_id})
+            if not tv or "seasons" not in tv:
+                return False
+
+            found = False
+            for s_idx, season in enumerate(tv["seasons"]):
+                for e_idx, episode in enumerate(season.get("episodes", [])):
+                    for q_idx, quality in enumerate(episode.get("telegram", [])):
+                        if quality.get("id") == quality_id:
+                            tv["seasons"][s_idx]["episodes"][e_idx]["telegram"][q_idx]["is_dead"] = False
+                            found = True
+                            break
+                    if found: break
+                if found: break
+
+            if found:
+                tv["updated_on"] = datetime.utcnow()
+                result = await self.dbs[db_key]["tv"].replace_one({"tmdb_id": tmdb_id}, tv)
+                return result.modified_count > 0
+
+        return False
+
     async def get_all_dead_links(self) -> List[dict]:
         """
         Scans all active storage databases for both movies and TV shows, returning a

--- a/Backend/helper/link_checker.py
+++ b/Backend/helper/link_checker.py
@@ -20,7 +20,17 @@ class DeadLinkChecker:
     async def _run_loop(self):
         # Wait a minute before starting the first scan so the bots can boot up
         await asyncio.sleep(60)
-        
+
+        # One-time healing pass: the previous version of _check_file_alive could not
+        # decode split-file IDs and wrongly flagged every split file as dead. Re-verify
+        # all currently-dead links and clear the flag on any that are actually alive.
+        try:
+            LOGGER.info("Running one-time dead-link re-verification (healing pass)...")
+            await self._recheck_dead_links()
+            LOGGER.info("Dead-link re-verification complete.")
+        except Exception as e:
+            LOGGER.error(f"Error during dead-link re-verification: {e}")
+
         while self.is_running:
             try:
                 LOGGER.info("Starting Dead Link Checker scan...")
@@ -87,31 +97,108 @@ class DeadLinkChecker:
             except Exception as e:
                 LOGGER.error(f"Error scanning TV shows in DB {i}: {e}")
 
+    async def _recheck_dead_links(self):
+        """
+        Re-verifies every telegram quality currently flagged as dead and clears the
+        flag for any that are actually alive. This repairs split files that were
+        incorrectly flagged by the old single-message-only liveness check.
+        """
+        from Backend.pyrofork.bot import multi_clients
+        if not multi_clients:
+            LOGGER.warning("No bot clients available for dead-link re-verification.")
+            return
+
+        client = multi_clients.get(0) or next(iter(multi_clients.values()))
+        restored = 0
+
+        for i in range(1, self.db.current_db_index + 1):
+            db_key = f"storage_{i}"
+            active_db = self.db.dbs[db_key]
+
+            # 1. Movies with at least one dead quality
+            try:
+                async for movie in active_db["movie"].find({"telegram.is_dead": True}):
+                    tmdb_id = movie.get("tmdb_id")
+                    for quality in movie.get("telegram", []):
+                        if quality.get("is_dead"):
+                            if await self._check_file_alive(client, quality.get("id")):
+                                LOGGER.info(f"Restoring live link for Movie {tmdb_id} (Quality: {quality.get('quality')})")
+                                await self.db.clear_dead_link("movie", tmdb_id, i, quality.get("id"))
+                                restored += 1
+                            await asyncio.sleep(0.5)
+            except Exception as e:
+                LOGGER.error(f"Error re-checking movies in DB {i}: {e}")
+
+            # 2. TV episodes with at least one dead quality
+            try:
+                async for tv in active_db["tv"].find({"seasons.episodes.telegram.is_dead": True}):
+                    tmdb_id = tv.get("tmdb_id")
+                    for season in tv.get("seasons", []):
+                        for ep in season.get("episodes", []):
+                            for quality in ep.get("telegram", []):
+                                if quality.get("is_dead"):
+                                    if await self._check_file_alive(client, quality.get("id")):
+                                        LOGGER.info(f"Restoring live link for TV {tmdb_id} S{season.get('season_number')}E{ep.get('episode_number')} (Quality: {quality.get('quality')})")
+                                        await self.db.clear_dead_link("tv", tmdb_id, i, quality.get("id"))
+                                        restored += 1
+                                    await asyncio.sleep(0.5)
+            except Exception as e:
+                LOGGER.error(f"Error re-checking TV shows in DB {i}: {e}")
+
+        LOGGER.info(f"Dead-link re-verification restored {restored} link(s).")
+
     async def _check_file_alive(self, client, quality_id: str) -> bool:
         """
-        Decodes the quality_id to a Telegram chat_id and message_id,
-        then attempts to fetch the message to see if it (and its media) still exist.
+        Decodes the quality_id and checks whether the underlying Telegram media
+        still exists. Supports two ID schemas:
+          - Single file:  {"chat_id": ..., "msg_id": ...}
+          - Split file:   {"parts": [{"chat_id": ..., "msg_id": ...}, ...]}
+        A split file is considered alive only if every one of its parts is alive.
         """
         try:
             decoded = await decode_string(quality_id)
-            if not decoded or "chat_id" not in decoded or "msg_id" not in decoded:
-                return False
-                
-            chat_id = int(f"-100{decoded['chat_id']}")
-            msg_id = int(decoded["msg_id"])
-
-            # Use get_messages to fetch exactly one message
-            messages = await client.get_messages(chat_id, message_ids=[msg_id])
-            if not messages or len(messages) == 0:
-                return False
-                
-            msg = messages[0]
-            if msg.empty or (msg.document is None and msg.video is None and msg.audio is None):
+            if not decoded:
                 return False
 
-            return True
+            # Split file: verify every part message still exists.
+            if "parts" in decoded:
+                parts = decoded.get("parts") or []
+                if not parts:
+                    return False
+                for part in parts:
+                    if not await self._check_single_message(
+                        client, part.get("chat_id"), part.get("msg_id")
+                    ):
+                        return False
+                return True
+
+            # Single file.
+            if "chat_id" not in decoded or "msg_id" not in decoded:
+                return False
+            return await self._check_single_message(
+                client, decoded["chat_id"], decoded["msg_id"]
+            )
 
         except Exception as e:
             # If the channel is banned, chat_id is invalid, or any other critical error occurs
             LOGGER.error(f"Link checker failed to resolve {quality_id}: {e}")
             return False
+
+    async def _check_single_message(self, client, raw_chat_id, raw_msg_id) -> bool:
+        """Fetch a single Telegram message and confirm it still carries media."""
+        if raw_chat_id is None or raw_msg_id is None:
+            return False
+
+        chat_id = int(f"-100{raw_chat_id}")
+        msg_id = int(raw_msg_id)
+
+        # Use get_messages to fetch exactly one message
+        messages = await client.get_messages(chat_id, message_ids=[msg_id])
+        if not messages or len(messages) == 0:
+            return False
+
+        msg = messages[0]
+        if msg.empty or (msg.document is None and msg.video is None and msg.audio is None):
+            return False
+
+        return True


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @weebzone :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

The dead-link checker was flagging every split file as a dead link, even when all of its part messages still existed on Telegram.

### Root cause
`DeadLinkChecker._check_file_alive` decoded each quality's `id` expecting a single-message payload `{chat_id, msg_id}`. Split files instead store `{parts: [{chat_id, msg_id}, ...]}` (see `_build_part_id_and_size` in `database.py`). Since a split-file payload has no top-level `chat_id`/`msg_id`, the guard returned `False` immediately, without ever contacting Telegram, so all split files were unconditionally marked `is_dead: True`.

### Changes
- `_check_file_alive` now understands both ID schemas. A split file is considered alive only if every part message is still alive (new `_check_single_message` helper).
- Added `Database.clear_dead_link()` to unflag a quality entry (mirrors `flag_dead_link`).
- Added a one-time `_recheck_dead_links()` healing pass on startup that re-verifies entries currently flagged `is_dead` and clears the flag on any that are actually alive, repairing split files mis-flagged by the old logic.

### Testing
- `python -m py_compile` passes for both modified files.
- Logic verified by tracing both single-file and split-file ID schemas through the decode path.