### PR TITLE
Replace subscription URL with bot URL + stream gating & subscription button fixes

### DIFF
--- a/Backend/config.py
+++ b/Backend/config.py
@@ -33,7 +33,6 @@ class Telegram:
     ADMIN_PASSWORD               = getenv("ADMIN_PASSWORD", "admin")
     SUBSCRIPTION                 = getenv("SUBSCRIPTION", "false").lower() == "true"
     SUBSCRIPTION_GROUP_ID        = int(getenv("SUBSCRIPTION_GROUP_ID", "0"))
-    SUBSCRIPTION_URL             = getenv("SUBSCRIPTION_URL", "https://t.me/")
     APPROVER_IDS                 = [int(x.strip()) for x in (getenv("APPROVER_IDS") or "").split(",") if x.strip().isdigit()]
     HTTP_PROXY_URL               = getenv("HTTP_Proxy_URL", "")
     SHOW_PROXY_AND_NON_PROXY_BOTH = getenv("SHOW_ProxyAndNonProxyBoth", "false").lower() == "true"

--- a/Backend/fastapi/routes/api_routes.py
+++ b/Backend/fastapi/routes/api_routes.py
@@ -580,8 +580,30 @@ async def manage_subscriber_api(user_id: int, payload: dict) -> dict:
             raise HTTPException(status_code=400, detail="Invalid action")
             
         success = await db.manage_subscriber(user_id, action, days)
+
+        # On revoke, also remove the user from the subscription group so the
+        # action takes effect immediately instead of waiting for the checker.
+        if success and action == "delete" and SettingsManager.current().subscription:
+            group_id = SettingsManager.current().subscription_group_id
+            if group_id:
+                try:
+                    # ban + unban kicks without permanently blocking re-join
+                    await StreamBot.ban_chat_member(group_id, user_id)
+                    await StreamBot.unban_chat_member(group_id, user_id)
+                except Exception as exc:
+                    LOGGER.warning(f"Revoke: could not remove user {user_id} from group: {exc}")
+
+        # Reflect the change immediately in the stremio membership cache.
         if success:
-            return {"status": "success", "message": "User subscription updated successfully"}
+            try:
+                from Backend.fastapi.routes.stremio_routes import invalidate_membership_cache
+                invalidate_membership_cache(user_id)
+            except Exception:
+                pass
+
+        if success:
+            verb = {"extend": "extended", "reduce": "reduced", "delete": "revoked"}.get(action, "updated")
+            return {"status": "success", "message": f"User subscription {verb} successfully"}
         else:
             raise HTTPException(status_code=404, detail="User not found or update failed")
     except HTTPException:
@@ -1049,7 +1071,7 @@ async def update_settings_api(payload: dict) -> dict:
 
     # Strip whitespace from string fields
     for key in ("tmdb_api", "base_url", "upstream_repo", "upstream_branch",
-                "admin_username", "admin_password", "http_proxy_url", "subscription_url",
+                "admin_username", "admin_password", "http_proxy_url",
                 "payment_instructions", "payment_qr_url"):
         if key in payload and isinstance(payload[key], str):
             payload[key] = payload[key].strip()

--- a/Backend/fastapi/routes/stremio_routes.py
+++ b/Backend/fastapi/routes/stremio_routes.py
@@ -10,6 +10,7 @@ from datetime import datetime, timezone, timedelta
 from Backend.fastapi.security.tokens import verify_token
 from Backend.logger import LOGGER
 from Backend.helper.global_search import global_search, is_global_search_enabled
+from Backend.pyrofork.bot import get_streambot_url
 
 router = APIRouter(prefix="/stremio", tags=["Stremio Addon"])
 
@@ -17,6 +18,27 @@ router = APIRouter(prefix="/stremio", tags=["Stremio Addon"])
 ADDON_NAME = "Telegram"
 ADDON_VERSION = __version__
 PAGE_SIZE = 15
+
+# Short-lived cache for subscription-group membership checks so Stremio's
+# frequent stream polling doesn't hammer Telegram's get_chat_member API.
+# Maps (group_id, user_id) -> (monotonic_timestamp, is_member).
+_membership_cache: dict = {}
+_MEMBERSHIP_TTL = 120  # seconds
+_MEMBERSHIP_CACHE_MAX = 5000  # hard cap to prevent unbounded growth
+
+
+def invalidate_membership_cache(user_id: int | None = None) -> None:
+    """Drop cached membership results.
+
+    Called after an admin revokes/kicks a user so the new state is reflected
+    on the very next stream request instead of waiting for the TTL. Pass
+    ``None`` to clear everything (e.g. when the group id changes).
+    """
+    if user_id is None:
+        _membership_cache.clear()
+        return
+    for key in [k for k in _membership_cache if k[1] == user_id]:
+        _membership_cache.pop(key, None)
 
 # Define available genres
 GENRES = [
@@ -409,6 +431,57 @@ async def _global_streams_for(token: str, imdb_id: str, media_type: str, season_
     return streams
 
 
+async def _is_subscription_member(user_id: int) -> bool:
+    """Return ``True`` when the user is currently a member of the configured
+    subscription group/channel.
+
+    Results are cached briefly because Stremio polls the stream endpoint
+    frequently and we don't want to hit Telegram's ``get_chat_member`` rate
+    limit on every request.
+
+    Fails *open* (returns ``True``) on unexpected errors — e.g. the bot lacks
+    admin rights or Telegram is temporarily unreachable — so a transient issue
+    never blocks a legitimate, paying user from streaming. A user who has
+    genuinely left/been removed raises ``UserNotParticipant`` and is blocked.
+    """
+    import time
+    from Backend.pyrofork.bot import StreamBot
+    from pyrogram.enums import ChatMemberStatus
+    from pyrogram.errors import UserNotParticipant
+
+    group_id = SettingsManager.current().subscription_group_id
+    if not group_id:
+        # No group configured — nothing to gate on.
+        return True
+
+    cache_key = (group_id, user_id)
+    cached = _membership_cache.get(cache_key)
+    now_ts = time.monotonic()
+    if cached and (now_ts - cached[0]) < _MEMBERSHIP_TTL:
+        return cached[1]
+
+    try:
+        member = await StreamBot.get_chat_member(group_id, user_id)
+        result = member.status not in (ChatMemberStatus.LEFT, ChatMemberStatus.BANNED)
+    except UserNotParticipant:
+        result = False
+    except Exception as e:
+        # Fail open and do NOT cache, so the next request retries.
+        LOGGER.warning(f"[SUBSCRIPTION] Membership check failed for user {user_id}: {e}")
+        return True
+
+    # Prune the cache if it grows too large (drop entries past their TTL,
+    # then fall back to clearing everything if still over the cap).
+    if len(_membership_cache) >= _MEMBERSHIP_CACHE_MAX:
+        for k in [k for k, v in _membership_cache.items() if (now_ts - v[0]) >= _MEMBERSHIP_TTL]:
+            _membership_cache.pop(k, None)
+        if len(_membership_cache) >= _MEMBERSHIP_CACHE_MAX:
+            _membership_cache.clear()
+
+    _membership_cache[cache_key] = (now_ts, result)
+    return result
+
+
 @router.get("/{token}/stream/{media_type}/{id}.json")
 async def get_streams(
     token: str,
@@ -421,12 +494,27 @@ async def get_streams(
         return {
             "streams": [
                 {
-                    "name": "🚫 Subscription Expired",
-                    "title": "Your subscription has expired.\nRenew via the bot to continue watching.",
-                    "url": SettingsManager.current().subscription_url
+                    "name": "🚫 Plan Expired",
+                    "title": "Your plan is expired.\nRenew it from the bot to continue watching.",
+                    "url": get_streambot_url()
                 }
             ]
         }
+
+    # When the subscription feature is on, the user must be a current member of
+    # the configured subscription group/channel to stream anything.
+    if SettingsManager.current().subscription:
+        user_id = token_data.get("user_id")
+        if user_id and not await _is_subscription_member(int(user_id)):
+            return {
+                "streams": [
+                    {
+                        "name": "📢 Join Required",
+                        "title": "First join the channel to stream it.\nTap here to open the bot and join.",
+                        "url": get_streambot_url()
+                    }
+                ]
+            }
 
     if token_data.get("limit_exceeded"):
         limit_type = token_data["limit_exceeded"]

--- a/Backend/fastapi/templates/access_manage.html
+++ b/Backend/fastapi/templates/access_manage.html
@@ -100,27 +100,27 @@
     }
 
     .glass-btn-success {
-        background: color-mix(in srgb, #22c55e 18%, transparent);
-        color: #bbf7d0;
-        border-color: color-mix(in srgb, #22c55e 40%, transparent);
+        background: linear-gradient(135deg, #22c55e, #16a34a);
+        color: #ffffff;
+        border-color: transparent;
     }
 
     .glass-btn-warning {
-        background: color-mix(in srgb, #f59e0b 20%, transparent);
-        color: #fde68a;
-        border-color: color-mix(in srgb, #f59e0b 40%, transparent);
+        background: linear-gradient(135deg, #f59e0b, #d97706);
+        color: #ffffff;
+        border-color: transparent;
     }
 
     .glass-btn-danger {
-        background: color-mix(in srgb, #ef4444 20%, transparent);
-        color: #fecaca;
-        border-color: color-mix(in srgb, #ef4444 40%, transparent);
+        background: linear-gradient(135deg, #ef4444, #dc2626);
+        color: #ffffff;
+        border-color: transparent;
     }
 
     .glass-btn-purple {
-        background: color-mix(in srgb, #a855f7 18%, transparent);
-        color: #e9d5ff;
-        border-color: color-mix(in srgb, #a855f7 40%, transparent);
+        background: linear-gradient(135deg, #a855f7, #9333ea);
+        color: #ffffff;
+        border-color: transparent;
     }
 
     .glass-input,

--- a/Backend/fastapi/templates/settings.html
+++ b/Backend/fastapi/templates/settings.html
@@ -243,19 +243,14 @@
         </label>
 
         <div id="sub-fields" style="{% if not settings.subscription %}display:none{% endif %}">
-            <div class="grid-2" style="margin-bottom:1rem">
-                <div>
-                    <label class="s-label" for="subscription_group_id">Subscription Group ID</label>
-                    <input type="number" id="subscription_group_id" class="s-input"
-                        value="{{ settings.subscription_group_id }}"
-                        placeholder="-100xxxxxxxx">
-                </div>
-                <div>
-                    <label class="s-label" for="subscription_url">Subscription URL</label>
-                    <input type="url" id="subscription_url" class="s-input"
-                        value="{{ settings.subscription_url }}"
-                        placeholder="https://t.me/your_group">
-                </div>
+            <div style="margin-bottom:1rem">
+                <label class="s-label" for="subscription_group_id">Subscription Group ID</label>
+                <input type="number" id="subscription_group_id" class="s-input"
+                    value="{{ settings.subscription_group_id }}"
+                    placeholder="-100xxxxxxxx">
+                <span style="color:var(--text-sec);font-size:0.78rem;display:block;margin-top:0.4rem">
+                    Users are pointed back to your bot automatically for renewals and joining.
+                </span>
             </div>
 
             <!-- Payment method -->
@@ -603,7 +598,6 @@ async function saveSettings() {
         auth_channels:                 collectList('auth_channels'),
         subscription:                  document.getElementById('subscription').checked,
         subscription_group_id:         parseInt(document.getElementById('subscription_group_id').value || '0', 10),
-        subscription_url:              document.getElementById('subscription_url').value.trim(),
         payment_instructions:          document.getElementById('payment_instructions').value.trim(),
         payment_qr_url:                document.getElementById('payment_qr_url').value.trim(),
         approver_ids:                  collectList('approver_ids').map(Number),
@@ -693,7 +687,6 @@ function renderSettings(s) {
     document.getElementById('upstream_repo').value = s.upstream_repo || '';
     document.getElementById('upstream_branch').value = s.upstream_branch || '';
     document.getElementById('subscription_group_id').value = s.subscription_group_id || 0;
-    document.getElementById('subscription_url').value = s.subscription_url || '';
     document.getElementById('http_proxy_url').value = s.http_proxy_url || '';
 
     // Simple multi-value lists

--- a/Backend/fastapi/templates/subscriptions_manage.html
+++ b/Backend/fastapi/templates/subscriptions_manage.html
@@ -103,21 +103,21 @@
     }
 
     .glass-btn-danger {
-        background: color-mix(in srgb, #ef4444 20%, transparent);
-        color: #fecaca;
-        border-color: color-mix(in srgb, #ef4444 40%, transparent);
+        background: linear-gradient(135deg, #ef4444, #dc2626);
+        color: #ffffff;
+        border-color: transparent;
     }
 
     .glass-btn-warning {
-        background: color-mix(in srgb, #f59e0b 20%, transparent);
-        color: #fde68a;
-        border-color: color-mix(in srgb, #f59e0b 40%, transparent);
+        background: linear-gradient(135deg, #f59e0b, #d97706);
+        color: #ffffff;
+        border-color: transparent;
     }
 
     .glass-btn-success {
-        background: color-mix(in srgb, #22c55e 18%, transparent);
-        color: #bbf7d0;
-        border-color: color-mix(in srgb, #22c55e 40%, transparent);
+        background: linear-gradient(135deg, #22c55e, #16a34a);
+        color: #ffffff;
+        border-color: transparent;
     }
 
     .glass-input,

--- a/Backend/helper/database.py
+++ b/Backend/helper/database.py
@@ -318,43 +318,52 @@ class Database:
         return [convert_objectid_to_str(u) for u in users]
 
     async def manage_subscriber(self, user_id: int, action: str, days: int = 0) -> bool:
-        user = await self.get_user(user_id)
-        if not user:
-            return False
-            
+        from datetime import timedelta
         now = datetime.utcnow()
-        if action == "extend" or action == "reduce":
-            from datetime import timedelta
-            current_expiry = user.get("subscription_expiry")
-            
+        user = await self.get_user(user_id)
+
+        if action in ("extend", "reduce"):
+            current_expiry = user.get("subscription_expiry") if user else None
+
             if action == "extend":
-                if current_expiry and current_expiry > now:
-                    new_expiry = current_expiry + timedelta(days=days)
-                else:
-                    new_expiry = now + timedelta(days=days)
-            else: # reduce
+                base = current_expiry if (current_expiry and current_expiry > now) else now
+                new_expiry = base + timedelta(days=days)
+            else:  # reduce
                 if current_expiry:
                     new_expiry = current_expiry - timedelta(days=days)
                     if new_expiry < now:
-                        new_expiry = now # Just expire them
+                        new_expiry = now  # Just expire them
                 else:
-                    new_expiry = now # Already expired or none
-            
+                    new_expiry = now  # Already expired / no subscription
+
             status = "active" if new_expiry > now else "expired"
-            
-            result = await self.dbs["tracking"]["users"].update_one(
+
+            # Upsert so the action works even when the user has no tracking
+            # record yet (e.g. a token-only entry on the Access page).
+            await self.dbs["tracking"]["users"].update_one(
                 {"_id": user_id},
-                {"$set": {"subscription_expiry": new_expiry, "subscription_status": status}}
+                {
+                    "$set": {"subscription_expiry": new_expiry, "subscription_status": status},
+                    "$setOnInsert": {
+                        "first_name": f"User {user_id}",
+                        "username": None,
+                        "created_at": now,
+                    },
+                },
+                upsert=True
             )
-            return result.modified_count > 0
-            
+            return True
+
         elif action == "delete":
-            result = await self.dbs["tracking"]["users"].update_one(
+            # Revoke: end the subscription immediately. Idempotent — succeeds
+            # even if the user has no active subscription so the button never
+            # returns a spurious 404.
+            await self.dbs["tracking"]["users"].update_one(
                 {"_id": user_id},
-                {"$unset": {"subscription_expiry": "", "subscription_status": ""}}
+                {"$set": {"subscription_status": "expired", "subscription_expiry": now}}
             )
-            return result.modified_count > 0
-            
+            return True
+
         return False
 
     async def assign_subscription(self, user_id: int, days: int) -> dict:

--- a/Backend/helper/settings_manager.py
+++ b/Backend/helper/settings_manager.py
@@ -17,7 +17,6 @@ _DEFAULTS: Dict[str, Any] = {
     "admin_password": "admin",
     "subscription": False,
     "subscription_group_id": 0,
-    "subscription_url": "https://t.me/",
     "approver_ids": [],
     "payment_instructions": "",
     "payment_qr_url": "",
@@ -47,7 +46,6 @@ def _seed_from_env() -> Dict[str, Any]:
         "admin_password":               Telegram.ADMIN_PASSWORD,
         "subscription":                 Telegram.SUBSCRIPTION,
         "subscription_group_id":        Telegram.SUBSCRIPTION_GROUP_ID,
-        "subscription_url":             Telegram.SUBSCRIPTION_URL,
         "approver_ids":                 list(Telegram.APPROVER_IDS),
         "global_search_channels":       [],
         "http_proxy_url":               Telegram.HTTP_PROXY_URL,
@@ -122,10 +120,6 @@ class Settings:
     @property
     def http_proxy_url(self) -> str:
         return str(self._d.get("http_proxy_url") or "")
-
-    @property
-    def subscription_url(self) -> str:
-        return str(self._d.get("subscription_url") or "https://t.me/")
 
     @property
     def payment_instructions(self) -> str:
@@ -279,7 +273,7 @@ class SettingsManager:
                 LOGGER.error(f"SettingsManager reinit subscription: {exc}")
                 results["subscription"] = f"error: {exc}"
         else:
-            sub_keys = {"subscription_group_id", "approver_ids", "subscription_url",
+            sub_keys = {"subscription_group_id", "approver_ids",
                         "payment_instructions", "payment_qr_url"}
             if any(old.get(k) != new.get(k) for k in sub_keys):
                 results["subscription"] = "settings reloaded in-memory"

--- a/Backend/helper/subscription_checker.py
+++ b/Backend/helper/subscription_checker.py
@@ -1,6 +1,7 @@
 import asyncio
 from pyrogram import Client
 from Backend.helper.settings_manager import SettingsManager
+from Backend.pyrofork.bot import get_streambot_url
 from Backend import db
 from datetime import datetime
 from Backend.logger import LOGGER
@@ -34,7 +35,7 @@ async def subscription_checker_loop(bot: Client):
                         user_id,
                         "❌ <b>Subscription Expired</b>\n\n"
                         "Your subscription has expired, and you have been removed from the private group.\n"
-                        f"Please go to {SettingsManager.current().subscription_url} and send /start to renew your subscription and regain access."
+                        f"Please open the bot {get_streambot_url()} and send /start to renew your subscription and regain access."
                     )
                     LOGGER.info(f"Kicked expired user {user_id}")
                 except Exception as e:
@@ -50,7 +51,7 @@ async def subscription_checker_loop(bot: Client):
                         user_id,
                         f"⚠️ <b>Subscription Expiring Soon</b>\n\n"
                         f"Your subscription will expire on <b>{expiry.strftime('%Y-%m-%d %H:%M UTC')}</b>.\n"
-                        f"Please go to {SettingsManager.current().subscription_url} and send /start to renew your plan before you lose access to the group!"
+                        f"Please open the bot {get_streambot_url()} and send /start to renew your plan before you lose access to the group!"
                     )
                     await db.mark_reminder_sent(user_id)
                     LOGGER.info(f"Sent expiry reminder to user {user_id}")

--- a/Backend/pyrofork/bot.py
+++ b/Backend/pyrofork/bot.py
@@ -33,6 +33,26 @@ client_dc_map = {}
 client_failures = {}
 client_avg_mbps = {}
 
+
+def get_streambot_url() -> str:
+    """Public ``t.me`` link of the Stream bot.
+
+    Used everywhere a user needs to be pointed back to the bot (renew an
+    expired plan, join the subscription channel, etc.). ``StreamBot.username``
+    is populated at startup in ``Backend/__main__.py`` after the client starts.
+    Falls back to ``https://t.me/`` if the username is not yet available.
+    """
+    try:
+        username = getattr(StreamBot, "username", None)
+        if not username:
+            me = getattr(StreamBot, "me", None)
+            username = getattr(me, "username", None) if me else None
+        if username:
+            return f"https://t.me/{username}"
+    except Exception:
+        pass
+    return "https://t.me/"
+
 if Userbot is not None:
     work_loads[USERBOT_CLIENT_INDEX] = 0
     client_failures[USERBOT_CLIENT_INDEX] = 0

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ Everything below is stored in the database and applied **instantly — no restar
 | **Upstream Repo / Branch** | Optional — used by `/restart` to auto-update (e.g. repo `weebzone/Telegram-Stremio`, branch `master`). |
 
 ### 💳 Subscription (optional)
-Turn this on to monetise access. Set the **Subscription Group ID**, **Subscription URL**, **Payment Instructions** (your UPI / bank / PayPal text), an optional **Payment QR image URL**, and the **Approver IDs** (who can approve requests). The full flow is described in [Subscription Management](#-subscription-management).
+Turn this on to monetise access. Set the **Subscription Group ID**, **Payment Instructions** (your UPI / bank / PayPal text), an optional **Payment QR image URL**, and the **Approver IDs** (who can approve requests). Renewal and "join the channel" prompts shown in Stremio point users back to **your bot automatically** — no separate URL to configure. The full flow is described in [Subscription Management](#-subscription-management).
 
 ### 🌐 Global Search (optional)
 Requires `USER_SESSION_STRING` in `config.env` plus one app restart to unlock. Then enable the toggle and add the **channel IDs** to search. Results that aren’t in your local catalog are tagged **🌐 GLOBAL** in Stremio.
@@ -552,19 +552,31 @@ The addon manifest updates dynamically per user:
 
 The manifest `version` encodes the expiry date — when an admin extends or revokes a subscription, the version changes and Stremio detects an update.
 
-### Expired Stream
+### Subscription Stream Gating
 
-When a user's subscription expires, instead of streams they see:
+When the subscription feature is enabled, the addon checks every stream request and shows a single actionable entry instead of the streams when the user isn't eligible. In both cases the stream link opens **your bot** (derived automatically from the bot's username — there is no URL to configure).
+
+**Plan expired** — the user's subscription has lapsed:
 
 ```json
 {
-  "name": "🚫 Subscription Expired",
-  "title": "Your subscription has expired.\nRenew via the bot to continue watching.",
-  "url": "https://t.me/your_bot"   ← SUBSCRIPTION_URL from config
+  "name": "🚫 Plan Expired",
+  "title": "Your plan is expired.\nRenew it from the bot to continue watching.",
+  "url": "https://t.me/your_bot"
 }
 ```
 
-Clicking the stream name opens the bot directly for renewal.
+**Not joined** — the user is active but has left / never joined the subscription channel (the `Subscription Group ID`):
+
+```json
+{
+  "name": "📢 Join Required",
+  "title": "First join the channel to stream it.\nTap here to open the bot and join.",
+  "url": "https://t.me/your_bot"
+}
+```
+
+Clicking the stream name opens the bot directly so the user can renew or rejoin. The membership check fails open — if Telegram is briefly unreachable or the bot can't read the group, legitimate users are never blocked.
 
 ### Configure & Reinstall Page
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @weebzone :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

This PR addresses several subscription-related requests:

- **Removed the configurable Subscription URL entirely** and replaced it with an auto-derived **StreamBot URL** (`https://t.me/{bot_username}`) via a new `get_streambot_url()` helper in `bot.py`. The username is already populated at startup. All consumers (Stremio expired stream, expiry/reminder DMs, settings UI) now use it. No `subscription_url`/`SUBSCRIPTION_URL` reference remains anywhere.
- **Stream gating when subscription is on:**
  - If the token's linked user is **not a member** of the subscription group/channel, Stremio shows a single `📢 Join Required — First join the channel to stream it` entry that links to the bot.
  - If the **plan is expired**, Stremio shows `🚫 Plan Expired — Renew it from the bot`.
  - Membership checks are cached (120s TTL, size-bounded, invalidated on revoke) so Stremio's frequent stream polling doesn't hit Telegram rate limits. The check fails *open* so a transient Telegram error never locks out paying users.
- **Fixed subscription admin buttons** on the Access and Subscription pages:
  - The reported **Revoke** bug (and Extend/Reduce) is fixed: `manage_subscriber` now upserts (works for token-only users on the Access page) and is idempotent — no more spurious 404s.
  - Revoke now also **kicks the user from the subscription group** (ban+unban) so it takes effect immediately.
  - Audited every button on both pages — all are correctly wired to valid endpoints (assign-plan, manage, link-user, delete-token, plan CRUD).
- **Fixed button text visibility across themes:** the colored action buttons (`success`/`warning`/`danger`/`purple`) used pale text that was invisible on light themes. They now use solid gradient backgrounds with white text on both admin pages.
- **Updated the README** to remove the Subscription URL docs and document the new Plan Expired / Join Required gating behavior.

## Testing

- `python -m py_compile` passes on all changed Python modules.
- Verified (via grep) that no `subscription_url`/`SUBSCRIPTION_URL` references remain in code, templates, env samples, or docs.
- Confirmed pyrogram enum/error import paths (`ChatMemberStatus`, `UserNotParticipant`) match existing usage in the codebase.
- Verified all admin button handlers map to registered FastAPI routes in `main.py`.

## Notes / Known limitations

- The membership gate fails *open* by design: a misconfigured `Subscription Group ID` or a bot lacking admin rights in the group will log a warning per request and not enforce gating. This is intentional to avoid locking out paying users on transient errors.
- After a revoke, the user remains visible in the subscriber list as `expired` (previously the record was removed) — kept for record-keeping.
- No automated test suite exists in the repo, so changes were validated by compilation and manual code-path review.