### PR TITLE
Add one-tap Hugging Face Spaces deployment

### DIFF
--- a/.github/workflows/huggingface-sync.yml
+++ b/.github/workflows/huggingface-sync.yml
@@ -1,0 +1,44 @@
+name: Deploy to Hugging Face Space
+
+# Auto-syncs this repo to your Hugging Face Docker Space.
+# Runs on every push to main/master and can also be triggered manually.
+#
+# One-time setup (all doable from a phone browser):
+#   1. Create a Docker Space on huggingface.co (SDK = Docker).
+#   2. HF profile -> Settings -> Access Tokens -> create a token with "Write" role.
+#   3. In this GitHub repo: Settings -> Secrets and variables -> Actions
+#        - Add a SECRET   named HF_TOKEN     = <your write token>
+#        - Add a VARIABLE named HF_SPACE_ID  = <your-username>/<your-space-name>
+#   4. Run this workflow (Actions tab -> Deploy to Hugging Face Space -> Run workflow),
+#      or just push any commit. The Space builds the Dockerfile automatically.
+
+on:
+  push:
+    branches: [main, master]
+  workflow_dispatch:
+
+jobs:
+  sync-to-hub:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      - name: Push to Hugging Face Space
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_SPACE_ID: ${{ vars.HF_SPACE_ID }}
+        run: |
+          set -e
+          if [ -z "$HF_TOKEN" ] || [ -z "$HF_SPACE_ID" ]; then
+            echo "::error::Missing HF_TOKEN secret or HF_SPACE_ID variable. See setup notes in this file."
+            exit 1
+          fi
+          HF_USER="${HF_SPACE_ID%%/*}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git push --force "https://${HF_USER}:${HF_TOKEN}@huggingface.co/spaces/${HF_SPACE_ID}.git" HEAD:main
+          echo "Pushed to https://huggingface.co/spaces/${HF_SPACE_ID}"

--- a/README.md
+++ b/README.md
@@ -761,9 +761,9 @@ sudo apt install caddy
 ➡️ `https://your-domain.com`
 
 
-## 🤗 Hugging Face Guide (Free, Phone-Friendly)
+## 🤗 Hugging Face Guide
 
-Deploy a **free, always-online** instance entirely from your **phone's browser** — no VPS, no domain, and no Docker knowledge required. Hugging Face builds the Docker image **on its own servers**; you only tap a few buttons.
+Deploy a **free, always-online** instance — no VPS, no domain, and no Docker knowledge required. Hugging Face builds the Docker image **on its own servers**; you only tap a few buttons.
 
 > 💡 **How it works:** this repo ships a GitHub Action that automatically pushes your code to your Hugging Face Space on every change. The Space then builds the included `Dockerfile` and runs your server.
 
@@ -836,9 +836,6 @@ https://<your-hf-username>-<your-space-name>.hf.space/stremio/manifest.json
 2. Log in (default `admin` / `admin`) and **immediately change the password**.
 3. Set your **Base URL** in the web Settings page to `https://<your-hf-username>-<your-space-name>.hf.space`.
 4. Add the manifest URL to Stremio/Nuvio and enjoy. 🎉
-
-> ⚠️ **Free-tier notes:** Free Spaces sleep after inactivity and have ephemeral storage. That's fine here — all media data lives in your external MongoDB, and regular addon traffic keeps the Space awake. Keep the Space **public** so clients can reach it.
-
 
 # 📺 Setting Up Your App (Nuvio Recommended)
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ pinned: false
   * [✅ Recommended Prerequisites](#-recommended-prerequisites)
   * [🐙 Heroku Guide](#-heroku-guide)
   * [🐳 VPS Guide (Recommended)](#-vps-guide-recommended)
+  * [🤗 Hugging Face Guide (Free, Phone-Friendly)](#-hugging-face-guide-free-phone-friendly)
 
 * [📺 Setting Up Your App (Nuvio Recommended)](#-setting-up-your-app-nuvio-recommended)
 
@@ -758,6 +759,85 @@ sudo apt install caddy
 
 ✅ Your API will now be available securely at:
 ➡️ `https://your-domain.com`
+
+
+## 🤗 Hugging Face Guide (Free, Phone-Friendly)
+
+Deploy a **free, always-online** instance entirely from your **phone's browser** — no VPS, no domain, and no Docker knowledge required. Hugging Face builds the Docker image **on its own servers**; you only tap a few buttons.
+
+> 💡 **How it works:** this repo ships a GitHub Action that automatically pushes your code to your Hugging Face Space on every change. The Space then builds the included `Dockerfile` and runs your server.
+
+### ⭐ Step 1: Star this Repository
+
+Open the repo and tap **⭐ Star** at the top right. It helps the project and keeps it on your radar.
+
+➡️ [github.com/weebzone/Telegram-Stremio](https://github.com/weebzone/Telegram-Stremio)
+
+### 🍴 Step 2: Fork the Repository
+
+Tap **Fork** (top right) → **Create fork**. This gives you your **own copy** so you can add private secrets and run the deploy workflow.
+
+### 🔑 Step 3: Create a Hugging Face Write Token
+
+1. Sign in (or sign up) at [huggingface.co](https://huggingface.co).
+2. Go to **Profile → Settings → Access Tokens**.
+3. Tap **Create new token**, choose the **Write** role, and copy the token.
+
+### 🚀 Step 4: Create a Docker Space
+
+1. Go to [huggingface.co/new-space](https://huggingface.co/new-space).
+2. Give it a name, select **Docker** as the SDK (pick the **Blank** template).
+3. Set visibility to **Public** (required so Stremio/Nuvio can reach your addon).
+4. Tap **Create Space**.
+
+Your Space ID is `<your-hf-username>/<your-space-name>` — note it down.
+
+### 🔐 Step 5: Add Deploy Credentials to Your GitHub Fork
+
+In **your forked repo** → **Settings → Secrets and variables → Actions**:
+
+| Type         | Name          | Value                                  |
+| ------------ | ------------- | -------------------------------------- |
+| **Secret**   | `HF_TOKEN`    | the Write token from Step 3            |
+| **Variable** | `HF_SPACE_ID` | `<your-hf-username>/<your-space-name>` |
+
+> Add the secret under the **Secrets** tab and the variable under the **Variables** tab.
+
+### 🤖 Step 6: Add Your Bot Secrets to the Space
+
+On your **Hugging Face Space → Settings → Variables and secrets**, add the same values you'd normally put in `config.env`:
+
+| Secret                | Required | Where to get it                        |
+| --------------------- | -------- | -------------------------------------- |
+| `API_ID`              | ✅        | [my.telegram.org](https://my.telegram.org) |
+| `API_HASH`            | ✅        | [my.telegram.org](https://my.telegram.org) |
+| `BOT_TOKEN`           | ✅        | [@BotFather](https://t.me/BotFather)   |
+| `OWNER_ID`            | ✅        | your numeric Telegram ID               |
+| `DATABASE`            | ✅        | two comma-separated MongoDB URIs       |
+| `USER_SESSION_STRING` | ⬜        | optional (Global Search)               |
+
+> ℹ️ You don't need a `config.env` file on Hugging Face — these secrets are read directly as environment variables. The included `Dockerfile` already listens on the right port (`app_port: 8000` is preset in this README).
+
+### ▶️ Step 7: Deploy
+
+In **your forked repo** → **Actions** tab → select **Deploy to Hugging Face Space** → **Run workflow**.
+
+After this first run, **every push to your fork auto-deploys**. Watch the build progress on your Hugging Face Space page — once it shows **Running**, you're live.
+
+### 🎬 Step 8: Use Your Addon
+
+Your addon manifest will be available at:
+
+```
+https://<your-hf-username>-<your-space-name>.hf.space/stremio/manifest.json
+```
+
+1. Open `https://<your-hf-username>-<your-space-name>.hf.space/login`
+2. Log in (default `admin` / `admin`) and **immediately change the password**.
+3. Set your **Base URL** in the web Settings page to `https://<your-hf-username>-<your-space-name>.hf.space`.
+4. Add the manifest URL to Stremio/Nuvio and enjoy. 🎉
+
+> ⚠️ **Free-tier notes:** Free Spaces sleep after inactivity and have ephemeral storage. That's fine here — all media data lives in your external MongoDB, and regular addon traffic keeps the Space awake. Keep the Space **public** so clients can reach it.
 
 
 # 📺 Setting Up Your App (Nuvio Recommended)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+---
+title: Telegram Stremio
+emoji: 🎬
+colorFrom: blue
+colorTo: purple
+sdk: docker
+app_port: 8000
+pinned: false
+---
 
 <p align="center">
   <img src="https://iili.io/KhN0ztj.png" alt="Logo" width="400"/>

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ pinned: false
   * [✅ Recommended Prerequisites](#-recommended-prerequisites)
   * [🐙 Heroku Guide](#-heroku-guide)
   * [🐳 VPS Guide (Recommended)](#-vps-guide-recommended)
-  * [🤗 Hugging Face Guide (Free, Phone-Friendly)](#-hugging-face-guide-free-phone-friendly)
+  * [🤗 Hugging Face Guide](#-hugging-face-guide)
 
 * [📺 Setting Up Your App (Nuvio Recommended)](#-setting-up-your-app-nuvio-recommended)
 


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @weebzone :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary
Makes the project deployable to Hugging Face Spaces (Docker SDK) with phone-friendly auto-sync, no laptop or git required after setup.

- Added HF Space metadata (`sdk: docker`, `app_port: 8000`) to the top of `README.md` so HF recognizes and builds the existing Dockerfile.
- Added `.github/workflows/huggingface-sync.yml` that force-pushes the repo to your HF Space on every push to `main`/`master` (and via manual trigger). The Space then builds the Dockerfile automatically.

## One-time setup (all from a phone browser)
1. Create a Docker Space on huggingface.co.
2. Create an HF access token with **Write** role.
3. In this repo: Settings -> Secrets and variables -> Actions:
   - Secret `HF_TOKEN` = your write token
   - Variable `HF_SPACE_ID` = `<username>/<space-name>`
4. Add your bot runtime secrets (API_ID, API_HASH, BOT_TOKEN, OWNER_ID, DATABASE, ...) in the **HF Space** settings (they map directly to the env vars `config.py` reads).

## Notes / verification
- Verified the server binds `0.0.0.0` on `Telegram.PORT` (default 8000), matching `app_port: 8000`.
- `config.py` reads pure env vars; the gitignored `config.env` is absent on HF so `load_dotenv` is a harmless no-op and HF secrets are picked up automatically.
- Dockerfile runs as root, so writing `log.txt`/downloads under `/app` works without permission changes.
- HF free Spaces sleep after inactivity and storage is ephemeral; this is fine since all data lives in external MongoDB. Keep the Space public so Stremio can reach the addon, and change the default admin password after first login.
- Not run: no automated tests exist for this change.