### PR TITLE
Fix split-file data usage & speed test, compact admin mobile UI

### DIFF
--- a/Backend/fastapi/routes/api_routes.py
+++ b/Backend/fastapi/routes/api_routes.py
@@ -285,6 +285,21 @@ async def revoke_token_api(token: str):
 
 # --- Speed Test API ---
 
+async def _resolve_speed_test_target(quality_id: str):
+    """Decode a quality_id into (chat_id, msg_id). Split files decode to a
+    'parts' list with no top-level ids, so fall back to the first part, which
+    lives in the same channel/DC and is representative of throughput."""
+    from Backend.helper.encrypt import decode_string
+
+    decoded = await decode_string(quality_id)
+    target = decoded["parts"][0] if decoded.get("parts") else decoded
+    msg_id = target.get("msg_id")
+    raw_cid = target.get("chat_id")
+    if not msg_id or not raw_cid:
+        return None, None, decoded
+    return int(f"-100{raw_cid}"), int(msg_id), decoded
+
+
 async def speed_test_api(
     quality_id: str = Query(..., description="Encoded quality ID from DB"),
     tmdb_id: int = Query(...),
@@ -295,23 +310,15 @@ async def speed_test_api(
     Decode quality_id using the same decode_string logic as the stream handler,
     then run a parallel download speed test across all connected bot clients.
     """
-    from Backend.helper.encrypt import decode_string
-
     try:
-        decoded = await decode_string(quality_id)
-        msg_id  = decoded.get("msg_id")
-        raw_cid = decoded.get("chat_id")
-
-        if not msg_id or not raw_cid:
+        chat_id, msg_id, decoded = await _resolve_speed_test_target(quality_id)
+        if not chat_id or not msg_id:
             raise HTTPException(
                 status_code=422,
                 detail=f"Decoded quality data is missing msg_id or chat_id. Decoded: {decoded}"
             )
 
-        # Stream handler adds -100 prefix for channel IDs
-        chat_id = int(f"-100{raw_cid}")
-
-        results = await run_speed_test(int(chat_id), int(msg_id))
+        results = await run_speed_test(chat_id, msg_id)
         return {"results": results, "total_clients_tested": len(results)}
 
     except HTTPException:
@@ -332,19 +339,15 @@ async def speed_test_stream_api(
     SSE version of the speed test. Streams each per-client result as a
     'data:' event the moment that client finishes, so the UI can update live.
     """
-    from Backend.helper.encrypt import decode_string
 
     async def event_generator():
-        # Decode quality_id → chat_id + message_id
+        # Decode quality_id → chat_id + message_id (split files test part 1)
         try:
-            decoded = await decode_string(quality_id)
-            msg_id  = decoded.get("msg_id")
-            raw_cid = decoded.get("chat_id")
-            if not msg_id or not raw_cid:
+            chat_id, msg_id, decoded = await _resolve_speed_test_target(quality_id)
+            if not chat_id or not msg_id:
                 payload = json.dumps({"type": "error", "message": f"Cannot decode quality_id. Got: {decoded}"})
                 yield f"data: {payload}\n\n"
                 return
-            chat_id = int(f"-100{raw_cid}")
         except Exception as exc:
             payload = json.dumps({"type": "error", "message": str(exc)})
             yield f"data: {payload}\n\n"

--- a/Backend/fastapi/templates/admin_dashboard.html
+++ b/Backend/fastapi/templates/admin_dashboard.html
@@ -145,6 +145,8 @@
 
   .table-scroll {
     overflow-x: auto;
+    max-height: 62vh;
+    overflow-y: auto;
   }
 
   .table-ui {
@@ -161,8 +163,11 @@
     text-transform: uppercase;
     letter-spacing: .06em;
     padding: 1rem 1.25rem;
-    background: color-mix(in srgb, var(--bg) 40%, transparent);
+    background: color-mix(in srgb, var(--card) 92%, var(--bg));
     border-bottom: 1px solid color-mix(in srgb, var(--border) 92%, transparent);
+    position: sticky;
+    top: 0;
+    z-index: 2;
   }
 
   .table-ui tbody td {
@@ -218,6 +223,53 @@
 
   .mobile-kv .key {
     color: var(--text-sec);
+  }
+
+  .bot-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+
+  .bot-card {
+    background: color-mix(in srgb, var(--bg) 68%, transparent);
+    border: 1px solid color-mix(in srgb, var(--border) 90%, transparent);
+    border-radius: 1.1rem;
+    padding: 0.85rem;
+  }
+
+  .bot-stat-num {
+    font-size: 1.15rem;
+    font-weight: 900;
+    line-height: 1.1;
+  }
+
+  .bot-stat-label {
+    font-size: 0.6rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: .04em;
+    color: var(--text-sec);
+    margin-top: .15rem;
+  }
+
+  .analytics-mobile-card {
+    padding: 0.75rem 0.85rem;
+    border-radius: 1rem;
+  }
+
+  .scroll-cap {
+    max-height: 62vh;
+    overflow-y: auto;
+    padding-right: 2px;
+  }
+
+  @media (min-width: 640px) {
+    .bot-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  }
+
+  @media (min-width: 1024px) {
+    .bot-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
   }
 
   .loading-dot {
@@ -361,7 +413,7 @@
                 </div>
             </div>
 
-            <div id="analytics-mobile" class="mobile-list">
+            <div id="analytics-mobile" class="mobile-list scroll-cap">
                 <div class="empty-state">
                     <i class="fas fa-spinner fa-spin mr-2 text-primary"></i> Loading analytics...
                 </div>
@@ -402,7 +454,7 @@
                 </div>
             </div>
 
-            <div id="dead-links-mobile" class="mobile-list">
+            <div id="dead-links-mobile" class="mobile-list scroll-cap">
                 <div class="empty-state">
                     <i class="fas fa-spinner fa-spin mr-2 text-primary"></i> Loading dead links...
                 </div>
@@ -440,35 +492,27 @@
             const workloadsWrap = document.getElementById('stat-workloads');
 
             if (data.bot_workloads && data.bot_workloads.length > 0) {
-                let html = '<div class="grid grid-cols-1 xl:grid-cols-2 gap-4">';
+                let html = '<div class="bot-grid scroll-cap">';
                 data.bot_workloads.forEach(b => {
+                    const failCls = Number(b.failures ?? 0) > 0 ? 'text-red-400' : 'text-text';
                     html += `
-                        <div class="workload-row rounded-3xl p-4 sm:p-5">
-                            <div class="flex flex-col gap-4">
-                                <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-                                    <div class="min-w-0">
-                                        <div class="text-base sm:text-lg font-bold text-text">${escapeHtml(b.display_name)}</div>
-                                        <div class="muted text-xs sm:text-sm mt-1">Bot performance summary</div>
-                                    </div>
-                                    <span class="${getStatusBadge(b.status)}">${escapeHtml(b.status)}</span>
+                        <div class="bot-card">
+                            <div class="flex items-center justify-between gap-2 mb-3">
+                                <div class="font-bold text-text truncate">${escapeHtml(b.display_name)}</div>
+                                <span class="${getStatusBadge(b.status)}">${escapeHtml(b.status)}</span>
+                            </div>
+                            <div class="grid grid-cols-3 gap-2 text-center">
+                                <div>
+                                    <div class="bot-stat-num text-text">${b.current_load ?? 0}</div>
+                                    <div class="bot-stat-label">Streams</div>
                                 </div>
-
-                                <div class="grid grid-cols-3 sm:grid-cols-3 gap-3">
-                                    <div class="glass-card-soft rounded-2xl p-4">
-                                        <div class="muted text-xs uppercase tracking-wider font-bold">Active Streams</div>
-                                        <div class="text-2xl font-black mt-2 text-text">${b.current_load ?? 0}</div>
-                                    </div>
-
-                                    <div class="glass-card-soft rounded-2xl p-4">
-                                        <div class="muted text-xs uppercase tracking-wider font-bold">Avg Speed</div>
-                                        <div class="text-2xl font-black mt-2 text-text">${Number(b.avg_mbps ?? 0).toFixed(1)}</div>
-                                        <div class="muted text-xs mt-1">MB/s</div>
-                                    </div>
-
-                                    <div class="glass-card-soft rounded-2xl p-4">
-                                        <div class="muted text-xs uppercase tracking-wider font-bold">Recent Failures</div>
-                                        <div class="text-2xl font-black mt-2 ${Number(b.failures ?? 0) > 0 ? 'text-red-400' : 'text-text'}">${b.failures ?? 0}</div>
-                                    </div>
+                                <div>
+                                    <div class="bot-stat-num text-text">${Number(b.avg_mbps ?? 0).toFixed(1)}</div>
+                                    <div class="bot-stat-label">MB/s</div>
+                                </div>
+                                <div>
+                                    <div class="bot-stat-num ${failCls}">${b.failures ?? 0}</div>
+                                    <div class="bot-stat-label">Fails</div>
                                 </div>
                             </div>
                         </div>
@@ -531,21 +575,17 @@
                 `;
 
                 mobileHtml += `
-                    <div class="mobile-card">
-                        <div class="flex items-start justify-between gap-3 mb-3">
-                            <div class="min-w-0">
-                                <div class="font-bold text-text">${escapeHtml(titleStr)}</div>
-                                <div class="muted text-xs font-mono mt-1 break-all">${escapeHtml(s.stream_id)}</div>
-                            </div>
+                    <div class="mobile-card analytics-mobile-card">
+                        <div class="flex items-center justify-between gap-2">
+                            <div class="font-semibold text-text truncate">${escapeHtml(titleStr)}</div>
                             <span class="${getStatusBadge(status)}">${escapeHtml(status)}</span>
                         </div>
-
-                        <div class="mobile-kv">
-                            <div class="key">Bot</div><div>Bot ${Number(s.client_index ?? 0) + 1} (DC${escapeHtml(s.dc_id)})</div>
-                            <div class="key">Transferred</div><div>${bytesStr}</div>
-                            <div class="key">Avg / Peak</div><div>${avg.toFixed(1)} / ${peak.toFixed(1)} MB/s</div>
-                            <div class="key">Duration</div><div>${durationStr}</div>
-                            <div class="key">Time</div><div>${timeStr}</div>
+                        <div class="flex flex-wrap gap-x-3 gap-y-1 muted text-xs mt-2">
+                            <span>Bot ${Number(s.client_index ?? 0) + 1} · DC${escapeHtml(s.dc_id)}</span>
+                            <span class="font-semibold text-text">${bytesStr}</span>
+                            <span>${avg.toFixed(1)}/${peak.toFixed(1)} MB/s</span>
+                            <span>${durationStr}</span>
+                            <span>${timeStr}</span>
                         </div>
                     </div>
                 `;

--- a/Backend/helper/utils.py
+++ b/Backend/helper/utils.py
@@ -4,6 +4,29 @@ from Backend import db
 from Backend.logger import LOGGER
 from Backend.helper.custom_dl import ACTIVE_STREAMS, RECENT_STREAMS
 
+
+def _collect_stream_bytes(stream_id: str, seen: dict) -> bool:
+    # A logical stream is either a single file (id == stream_id) or a set of
+    # split parts registered as "{stream_id}-p{index}". Fold the highest byte
+    # count ever observed per sub-stream so totals survive RECENT_STREAMS
+    # eviction. Returns whether any matching sub-stream is still active.
+    prefix = f"{stream_id}-p"
+
+    def matches(sid):
+        return sid == stream_id or (sid and sid.startswith(prefix))
+
+    active = False
+    for sid, info in ACTIVE_STREAMS.items():
+        if matches(sid):
+            seen[sid] = max(seen.get(sid, 0), info.get("total_bytes", 0))
+            active = True
+    for rec in RECENT_STREAMS:
+        sid = rec.get("stream_id")
+        if matches(sid):
+            seen[sid] = max(seen.get(sid, 0), rec.get("total_bytes", 0))
+    return active
+
+
 async def track_usage(stream_id: str, token: str, token_data: dict):
     await asyncio.sleep(2)
     limits = token_data.get("limits", {}) if token_data else {}
@@ -12,48 +35,46 @@ async def track_usage(stream_id: str, token: str, token_data: dict):
     monthly_limit_gb = limits.get("monthly_limit_gb")
     initial_daily_bytes = usage.get("daily", {}).get("bytes", 0)
     initial_monthly_bytes = usage.get("monthly", {}).get("bytes", 0)
+
+    seen: dict = {}
     last_tracked_bytes = 0
+    started = False
+    idle_polls = 0
     update_interval = 10
+
+    async def flush(current: int):
+        nonlocal last_tracked_bytes
+        delta = current - last_tracked_bytes
+        if delta > 0:
+            try:
+                await db.update_token_usage(token, delta)
+                last_tracked_bytes = current
+            except Exception as e:
+                LOGGER.error(f"Usage update failed: {e}")
+
     try:
         while True:
             await asyncio.sleep(update_interval)
-            stream_info = ACTIVE_STREAMS.get(stream_id)
-            if not stream_info:
-                for rec in RECENT_STREAMS:
-                    if rec.get("stream_id") == stream_id:
-                        final_bytes = rec.get("total_bytes", 0)
-                        delta = final_bytes - last_tracked_bytes
-                        if delta > 0:
-                            try:
-                                await db.update_token_usage(token, delta)
-                            except Exception as e:
-                                LOGGER.error(f"Final usage update failed: {e}")
-                        break
-                return
-            current_bytes = stream_info.get("total_bytes", 0)
-            delta = current_bytes - last_tracked_bytes
-            if delta > 0:
-                try:
-                    await db.update_token_usage(token, delta)
-                    last_tracked_bytes = current_bytes
-                except Exception as e:
-                    LOGGER.error(f"Periodic usage update failed: {e}")
+            active = _collect_stream_bytes(stream_id, seen)
+            current_bytes = sum(seen.values())
+            await flush(current_bytes)
+
             if daily_limit_gb and daily_limit_gb > 0:
-                current_daily_gb = (initial_daily_bytes + current_bytes) / (1024 ** 3)
-                if current_daily_gb >= daily_limit_gb:
-                    LOGGER.debug(f"Daily limit reached for token, stream {stream_id} may be blocked by verify_token")
+                if (initial_daily_bytes + current_bytes) / (1024 ** 3) >= daily_limit_gb:
+                    LOGGER.debug(f"Daily limit reached for stream {stream_id}")
             if monthly_limit_gb and monthly_limit_gb > 0:
-                current_monthly_gb = (initial_monthly_bytes + current_bytes) / (1024 ** 3)
-                if current_monthly_gb >= monthly_limit_gb:
-                    LOGGER.debug(f"Monthly limit reached for token, stream {stream_id} may be blocked by verify_token")
+                if (initial_monthly_bytes + current_bytes) / (1024 ** 3) >= monthly_limit_gb:
+                    LOGGER.debug(f"Monthly limit reached for stream {stream_id}")
+
+            if active:
+                started = True
+                idle_polls = 0
+            else:
+                # Exit once a started stream has gone quiet, or if it never
+                # showed up within the startup grace window.
+                idle_polls += 1
+                if (started and idle_polls >= 2) or (not started and idle_polls >= 6):
+                    return
     except asyncio.CancelledError:
-        stream_info = ACTIVE_STREAMS.get(stream_id)
-        if stream_info:
-            current_bytes = stream_info.get("total_bytes", 0)
-            delta = current_bytes - last_tracked_bytes
-            if delta > 0:
-                try:
-                    await db.update_token_usage(token, delta)
-                    LOGGER.info(f"Cancelled - final update for {stream_id}: {delta} bytes")
-                except Exception as e:
-                    LOGGER.error(f"Cancelled usage update failed: {e}")
+        _collect_stream_bytes(stream_id, seen)
+        await flush(sum(seen.values()))


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @weebzone :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

Addresses three issues, with the split-file bugs being the main fixes:

### 1. Data usage tracking was wrong (counted ~0) for split files
`virtual_media_streamer` starts `track_usage(stream_id, ...)` with the base stream id, but `virtual_stream_generator` registers each part in `ACTIVE_STREAMS` under a derived id `{stream_id}-p{index}`. So the tracker looked up the base id, found nothing, and exited immediately — **split-file streams were never counted against a token's data usage** (single files were fine).

`track_usage` now folds byte counts across the whole logical stream (base id **and** all `-p{n}` parts) via a small helper, keeping the highest value seen per sub-stream so counts survive `RECENT_STREAMS` eviction. A short startup grace + teardown settle window prevents premature exit while a split stream hands off between parts. Single-file behaviour is unchanged.

### 2. Speed test failed for split files
Both speed-test endpoints did `decoded.get("msg_id")`, but split files decode to `{"parts": [...]}` with no top-level `msg_id`/`chat_id`, so they returned 422 / errored. Added a shared `_resolve_speed_test_target()` that falls back to the first part (same channel/DC, representative of throughput) for split files, used by both the JSON and SSE endpoints.

### 3. Admin dashboard scrolled too much on mobile (many bots + analytics)
- Bot Health cards: replaced the tall 3-stacked-subcard layout with compact cards in a denser grid (2 cols on mobile, 3 at 640px, 4 at 1024px).
- Analytics mobile cards condensed from a 6-row key/value grid to a title+status row plus one wrapped stats line.
- Long lists (bots, analytics, dead links) are now height-capped with internal scrolling, and desktop tables gained a sticky header, so the page no longer grows unbounded.

## Testing
- `python -m py_compile` passes for `utils.py`, `api_routes.py`, and `stream_routes.py`.
- Admin dashboard changes are CSS + JS template markup only; no backend template variables were touched.

## Notes / limitations
- Split-file streams still log one analytics row per part (the aggregate byte total remains correct); this PR does not merge those rows.
- UI changes verified by code review; a visual check on a real device is recommended.