### PR TITLE
Feat: Integrate AniBridge Mappings for Anime Channels and Resolve Absolute Episode Parsing (e.g., One Piece)

### DIFF
--- a/Backend/helper/anime_mapping.py
+++ b/Backend/helper/anime_mapping.py
@@ -1,0 +1,96 @@
+import os
+import json
+from typing import Optional, Tuple
+from Backend.logger import LOGGER
+
+MAPPINGS_FILE = os.path.join(os.path.dirname(__file__), "mappings.min.json")
+_mappings_data = None
+
+def load_mapping() -> dict:
+    global _mappings_data
+    if _mappings_data is not None:
+        return _mappings_data
+    
+    if os.path.exists(MAPPINGS_FILE):
+        try:
+            with open(MAPPINGS_FILE, "r", encoding="utf-8") as f:
+                _mappings_data = json.load(f)
+            LOGGER.info("AniBridge mappings loaded successfully from local file.")
+            return _mappings_data
+        except Exception as e:
+            LOGGER.error(f"Failed to load local AniBridge mappings: {e}")
+    else:
+        LOGGER.warning(f"AniBridge mappings file not found at {MAPPINGS_FILE}. Please run scripts/update_anime_mappings.py manually.")
+        
+    _mappings_data = {}
+    return _mappings_data
+
+def parse_range_str(r_str: str) -> Tuple[int, Optional[int]]:
+    r_str = r_str.strip()
+    if "-" not in r_str:
+        try:
+            val = int(r_str)
+            return val, val
+        except ValueError:
+            return 0, 0
+            
+    parts = r_str.split("-")
+    try:
+        start = int(parts[0])
+    except ValueError:
+        start = 0
+        
+    if len(parts) > 1 and parts[1].strip():
+        try:
+            end = int(parts[1])
+        except ValueError:
+            end = None
+    else:
+        end = None
+        
+    return start, end
+
+def _map_provider(title: str, absolute_episode: int, provider: str, anilist_id: Optional[int] = None) -> Optional[Tuple[int, int]]:
+    # Fallback/default logic for One Piece
+    if not anilist_id:
+        if title.lower() == "one piece":
+            anilist_id = 21
+        else:
+            return None
+            
+    data = load_mapping()
+    ani_key = f"anilist:{anilist_id}"
+    if ani_key not in data:
+        return None
+        
+    ani_mappings = data[ani_key]
+    prefix = f"{provider}:"
+    for key, range_map in ani_mappings.items():
+        if not key.startswith(prefix):
+            continue
+            
+        parts = key.split(":")
+        if len(parts) < 3 or not parts[-1].startswith("s"):
+            continue
+            
+        try:
+            season = int(parts[-1][1:])
+        except ValueError:
+            continue
+            
+        for src_range, tgt_range in range_map.items():
+            src_start, src_end = parse_range_str(src_range)
+            tgt_start, tgt_end = parse_range_str(tgt_range)
+            
+            if src_start <= absolute_episode and (src_end is None or absolute_episode <= src_end):
+                offset = absolute_episode - src_start
+                mapped_ep = tgt_start + offset
+                return season, mapped_ep
+                
+    return None
+
+def map_tvdb(title: str, absolute_episode: int, anilist_id: Optional[int] = None) -> Optional[Tuple[int, int]]:
+    return _map_provider(title, absolute_episode, "tvdb_show", anilist_id)
+
+def map_tmdb(title: str, absolute_episode: int, anilist_id: Optional[int] = None) -> Optional[Tuple[int, int]]:
+    return _map_provider(title, absolute_episode, "tmdb_show", anilist_id)

--- a/Backend/helper/anime_parser.py
+++ b/Backend/helper/anime_parser.py
@@ -1,0 +1,99 @@
+import re
+from typing import Optional
+from Backend.helper.pyro import clean_filename
+from Backend.helper.metadata import parse_media_name
+
+_QUALITY_PATTERNS = [
+    (r"\b2160p\b|\b4k\b", "2160p"),
+    (r"\b1440p\b|\b2k\b", "1440p"),
+    (r"\b1080p\b|\bfhd\b", "1080p"),
+    (r"\b720p\b|\bhd\b", "720p"),
+    (r"\b480p\b|\bsd\b", "480p"),
+    (r"\b360p\b", "360p")
+]
+
+def extract_quality_single(text: str) -> str:
+    if not text:
+        return ""
+    text_lower = text.lower()
+    for pattern, label in _QUALITY_PATTERNS:
+        if re.search(pattern, text_lower):
+            return label
+    return ""
+
+def extract_quality(filename: str, caption: str) -> str:
+    # 1. Try filename quality
+    q = extract_quality_single(filename)
+    if q:
+        return q
+    # 2. Try caption quality
+    q = extract_quality_single(caption)
+    if q:
+        return q
+    # 3. Default to 720p for anime channels
+    return "720p"
+
+def extract_absolute_episode_single(text: str) -> Optional[int]:
+    if not text:
+        return None
+    
+    # Normalize separators (underscores, dots, dashes) to spaces for clean boundaries
+    normalized = re.sub(r"[._-]+", " ", text)
+    
+    # 1. Look for explicit episode markers (ep, episode, e, etc.)
+    for pattern in [
+        r"\b(?:ep|episode|e|eps|sp)\.?\s*(\d+)\b",
+        r"\b(\d+)\s*(?:ep|episode|e|eps)\b"
+    ]:
+        matches = re.findall(pattern, normalized, re.IGNORECASE)
+        if matches:
+            return int(matches[0])
+            
+    # 2. Look for standalone numbers, excluding standard resolutions and common years
+    candidates = re.findall(r"\b(\d{1,4})\b", normalized)
+    for cand in candidates:
+        val = int(cand)
+        if val in (1080, 2160, 1440, 720, 480, 360, 240):
+            continue
+        if 1990 <= val <= 2030:
+            continue
+        return val
+        
+    return None
+
+def extract_absolute_episode(filename: str, caption: str) -> Optional[int]:
+    # Prefer filename, then caption
+    ep = extract_absolute_episode_single(clean_filename(filename))
+    if ep is not None:
+        return ep
+    return extract_absolute_episode_single(clean_filename(caption))
+
+def extract_anime_title(filename: str, caption: str) -> str:
+    combined = f"{filename} {caption}".lower()
+    if "one piece" in combined:
+        return "One Piece"
+        
+    parsed_fn = parse_media_name(clean_filename(filename))
+    if parsed_fn.get("title"):
+        return parsed_fn["title"]
+    parsed_cap = parse_media_name(clean_filename(caption))
+    return parsed_cap.get("title") or ""
+
+def parse_anime_message(filename: str, caption: str) -> dict:
+    cleaned_fn = clean_filename(filename) if filename else ""
+    cleaned_cap = clean_filename(caption) if caption else ""
+    
+    parsed_fn = parse_media_name(cleaned_fn)
+    parsed_cap = parse_media_name(cleaned_cap)
+    
+    title = extract_anime_title(filename, caption)
+    abs_ep = extract_absolute_episode(filename, caption)
+    quality = extract_quality(filename, caption)
+    year = parsed_fn.get("year") or parsed_cap.get("year")
+    
+    return {
+        "title": title,
+        "absolute_episode": abs_ep,
+        "quality": quality,
+        "year": year
+    }

--- a/Backend/helper/manual_add.py
+++ b/Backend/helper/manual_add.py
@@ -56,12 +56,50 @@ async def resolve_telegram_message(client, url: str = None, chat_id=None, msg_id
     #----- Prefer the caption over the raw file name, then normalise it to the exact
     #----- filename receiver.py stores (clean, split-suffix stripped, video extension).
     caption = (getattr(message, "caption", None) or "").strip()
-    raw_name = caption or getattr(media, "file_name", None) or "video"
+    from Backend.helper.metadata import _is_anime_channel
+    
+    if _is_anime_channel(message.chat.id):
+        raw_name = getattr(media, "file_name", None) or caption or "video"
+    else:
+        raw_name = caption or getattr(media, "file_name", None) or "video"
+        
     cleaned = clean_filename(raw_name)
     split_info = parse_split_info(cleaned)
     raw_size = getattr(media, "file_size", 0) or 0
-    parsed = parse_media_name(strip_part_suffix(cleaned) if split_info else cleaned)
     file_name = finalize_media_name(raw_name, bool(split_info))
+
+    if _is_anime_channel(message.chat.id):
+        from Backend.helper.anime_parser import parse_anime_message
+        from Backend.helper.anime_mapping import map_tvdb
+        from Backend.helper.anime import search_anime
+
+        raw_file_name = getattr(media, "file_name", None) or "video"
+        parsed_anime = parse_anime_message(raw_file_name, caption)
+        title_val = parsed_anime["title"]
+        abs_ep = parsed_anime["absolute_episode"]
+        anilist_id = None
+        if abs_ep is not None and title_val.lower() != "one piece":
+            try:
+                media_info = await search_anime(title_val)
+                if media_info:
+                    anilist_id = media_info.get("id")
+            except Exception as e:
+                LOGGER.warning(f"Failed to lookup AniList ID for '{title_val}': {e}")
+        
+        season_val = 1
+        episode_val = abs_ep or 1
+        if abs_ep is not None:
+            mapped = map_tvdb(title_val, abs_ep, anilist_id=anilist_id)
+            if mapped:
+                season_val, episode_val = mapped
+                
+        parsed = {
+            "season": season_val,
+            "episode": episode_val,
+            "quality": parsed_anime["quality"]
+        }
+    else:
+        parsed = parse_media_name(strip_part_suffix(cleaned) if split_info else cleaned)
 
     #----- Real video dimensions beat the filename; documents fall back to the name
     height = getattr(media, "height", 0) or 0

--- a/Backend/helper/metadata.py
+++ b/Backend/helper/metadata.py
@@ -757,7 +757,7 @@ async def fetch_movie_metadata(title, encoded_string, year=None, quality=None, d
 
 
 #----- ── Main entry point ────────────────────────────────────────────────────────
-async def metadata(filename: str, channel: int, msg_id, override_id: str = None) -> dict | None:
+async def metadata(filename: str, channel: int, msg_id, override_id: str = None, parsed: dict | None = None) -> dict | None:
     if _MULTIPART_RE.search(filename):
         LOGGER.info(f"Skipping {filename}: split video file not meant to be combined in Stremio")
         return None
@@ -769,12 +769,14 @@ async def metadata(filename: str, channel: int, msg_id, override_id: str = None)
     part_number = split_info[1] if split_info else None
     parse_target = strip_part_suffix(filename) if split_info else filename
 
-    try:
-        parsed = parse_media_name(parse_target)
-    except Exception as e:
-        LOGGER.error(f"Parsing failed for {filename}: {e}\n{traceback.format_exc()}")
-        return None
+    if parsed is None:
+        try:
+            parsed = parse_media_name(parse_target)
+        except Exception as e:
+            LOGGER.error(f"Parsing failed for {filename}: {e}\n{traceback.format_exc()}")
+            return None
 
+    absolute_episode = parsed.get("absolute_episode")
     combined = parse_combined_episodes(parse_target)
 
     excess = parsed.get("excess")
@@ -789,31 +791,6 @@ async def metadata(filename: str, channel: int, msg_id, override_id: str = None)
     quality = parsed.get("quality")
 
     anime_channel = _is_anime_channel(channel)
-
-    #----- Normalise One Piece absolute episodes on anime channels to TV routing
-    if anime_channel and not combined:
-        normalized_fn = re.sub(r"[._-]+", " ", parse_target.lower())
-        if "one piece" in normalized_fn:
-            match_before = re.search(r"\b(1\d{3})\s+one\s+piece\b", normalized_fn)
-            match_after = re.search(r"\bone\s+piece\b.*?\b(?:ep|episode\b)?\s*(1\d{3})\b", normalized_fn)
-            
-            ep_num = None
-            if match_before:
-                ep_num = int(match_before.group(1))
-            elif match_after:
-                ep_num = int(match_after.group(1))
-            else:
-                match_fallback = re.search(r"\bone\s+piece\b\s*(?:ep|episode\b)?\s*(1\d{3})\b", normalized_fn)
-                if match_fallback:
-                    ep_num = int(match_fallback.group(1))
-            
-            if ep_num is not None and 1000 <= ep_num <= 2000:
-                title = "One Piece"
-                season = 1
-                episode = ep_num
-                parsed["title"] = title
-                parsed["season"] = season
-                parsed["episode"] = episode
 
     if combined:
         season, episode = combined["season"], combined["start"] or 1
@@ -846,7 +823,13 @@ async def metadata(filename: str, channel: int, msg_id, override_id: str = None)
             LOGGER.info(f"Fetching TV metadata: {title} S{season:02d}E{episode:02d} (year={year})")
             result = None
             if not default_id and anime_channel:
-                result = await _fetch_anime_tv(title, season, episode, encoded_string, year, quality)
+                result = await _fetch_anime_tv(title, 1, absolute_episode or episode, encoded_string, year, quality)
+                if result:
+                    result["season_number"] = season
+                    result["episode_number"] = episode
+                    ep_title = result.get("episode_title") or ""
+                    if not ep_title or ep_title.startswith("S01E") or ep_title == f"S01E{absolute_episode or episode:02d}":
+                        result["episode_title"] = f"S{season:02d}E{episode:02d}"
             if result is None:
                 result = await fetch_tv_metadata(title, season, episode, encoded_string, year, quality, default_id)
             if result is not None and combined:

--- a/Backend/helper/metadata.py
+++ b/Backend/helper/metadata.py
@@ -788,6 +788,33 @@ async def metadata(filename: str, channel: int, msg_id, override_id: str = None)
     year = parsed.get("year")
     quality = parsed.get("quality")
 
+    anime_channel = _is_anime_channel(channel)
+
+    #----- Normalise One Piece absolute episodes on anime channels to TV routing
+    if anime_channel and not combined:
+        normalized_fn = re.sub(r"[._-]+", " ", parse_target.lower())
+        if "one piece" in normalized_fn:
+            match_before = re.search(r"\b(1\d{3})\s+one\s+piece\b", normalized_fn)
+            match_after = re.search(r"\bone\s+piece\b.*?\b(?:ep|episode\b)?\s*(1\d{3})\b", normalized_fn)
+            
+            ep_num = None
+            if match_before:
+                ep_num = int(match_before.group(1))
+            elif match_after:
+                ep_num = int(match_after.group(1))
+            else:
+                match_fallback = re.search(r"\bone\s+piece\b\s*(?:ep|episode\b)?\s*(1\d{3})\b", normalized_fn)
+                if match_fallback:
+                    ep_num = int(match_fallback.group(1))
+            
+            if ep_num is not None and 1000 <= ep_num <= 2000:
+                title = "One Piece"
+                season = 1
+                episode = ep_num
+                parsed["title"] = title
+                parsed["season"] = season
+                parsed["episode"] = episode
+
     if combined:
         season, episode = combined["season"], combined["start"] or 1
     elif isinstance(season, list) or isinstance(episode, list):
@@ -812,7 +839,7 @@ async def metadata(filename: str, channel: int, msg_id, override_id: str = None)
         encoded_string = None
 
     group_key = f"{channel}:{quality}:{split_info[0]}" if split_info else None
-    anime_channel = _is_anime_channel(channel)
+
 
     try:
         if season and episode:

--- a/Backend/helper/scan_manager.py
+++ b/Backend/helper/scan_manager.py
@@ -457,11 +457,17 @@ class ScanManager:
             return
 
         file = message.video or message.document
-        title = message.caption or file.file_name
+        channel_int = int(str(chat_id).replace("-100", ""))
+        from Backend.helper.metadata import _is_anime_channel
+        
+        if _is_anime_channel(channel_int):
+            title = file.file_name or message.caption or "video"
+        else:
+            title = message.caption or file.file_name or "video"
+            
         msg_id = message.id
         raw_size = file.file_size
         size = get_readable_file_size(file.file_size)
-        channel_int = int(str(chat_id).replace("-100", ""))
 
         try:
             if await self._stream_id_exists(channel_int, msg_id):
@@ -471,7 +477,42 @@ class ScanManager:
             LOGGER.warning(f"[ScanManager] Dup-check error msg {msg_id}: {e}")
 
         try:
-            metadata_info = await metadata(clean_filename(title), channel_int, msg_id)
+            if _is_anime_channel(channel_int):
+                from Backend.helper.anime_parser import parse_anime_message
+                from Backend.helper.anime_mapping import map_tvdb
+                from Backend.helper.anime import search_anime
+
+                parsed = parse_anime_message(file.file_name, message.caption)
+                title_val = parsed["title"]
+                abs_ep = parsed["absolute_episode"]
+                anilist_id = None
+                if abs_ep is not None and title_val.lower() != "one piece":
+                    try:
+                        media_info = await search_anime(title_val)
+                        if media_info:
+                            anilist_id = media_info.get("id")
+                    except Exception as e:
+                        LOGGER.warning(f"Failed to lookup AniList ID for '{title_val}': {e}")
+                
+                season_val = 1
+                episode_val = abs_ep or 1
+                if abs_ep is not None:
+                    mapped = map_tvdb(title_val, abs_ep, anilist_id=anilist_id)
+                    if mapped:
+                        season_val, episode_val = mapped
+                
+                parsed_arg = {
+                    "title": title_val,
+                    "season": season_val,
+                    "episode": episode_val,
+                    "quality": parsed["quality"],
+                    "year": parsed["year"],
+                    "absolute_episode": abs_ep
+                }
+                meta_filename = file.file_name or title
+                metadata_info = await metadata(clean_filename(meta_filename), channel_int, msg_id, parsed=parsed_arg)
+            else:
+                metadata_info = await metadata(clean_filename(title), channel_int, msg_id)
         except Exception as e:
             LOGGER.warning(f"[ScanManager] Metadata exception for msg {msg_id}: {e}")
             metadata_info = None

--- a/Backend/pyrofork/plugins/receiver.py
+++ b/Backend/pyrofork/plugins/receiver.py
@@ -46,8 +46,12 @@ def _is_manual_channel(chat_id) -> bool:
 #----- Common message field extraction shared by the channel handlers
 def _extract_fields(message: Message):
     file = message.video or message.document
-    title = message.caption or file.file_name
     channel = str(message.chat.id).replace("-100", "")
+    from Backend.helper.metadata import _is_anime_channel
+    if _is_anime_channel(message.chat.id):
+        title = file.file_name or message.caption or "video"
+    else:
+        title = message.caption or file.file_name or "video"
     return file, title, message.id, file.file_size, get_readable_file_size(file.file_size), channel
 
 
@@ -103,9 +107,46 @@ async def file_receive_handler(client: Client, message: Message):
             await message.reply_text("> Not supported")
             return
 
-        _, title, msg_id, raw_size, size, channel = _extract_fields(message)
+        file, title, msg_id, raw_size, size, channel = _extract_fields(message)
+        from Backend.helper.metadata import _is_anime_channel
+        
+        if _is_anime_channel(message.chat.id):
+            from Backend.helper.anime_parser import parse_anime_message
+            from Backend.helper.anime_mapping import map_tvdb
+            from Backend.helper.anime import search_anime
 
-        metadata_info = await metadata(clean_filename(title), int(channel), msg_id)
+            parsed = parse_anime_message(file.file_name, message.caption)
+            title_val = parsed["title"]
+            abs_ep = parsed["absolute_episode"]
+            anilist_id = None
+            if abs_ep is not None and title_val.lower() != "one piece":
+                try:
+                    media_info = await search_anime(title_val)
+                    if media_info:
+                        anilist_id = media_info.get("id")
+                except Exception as e:
+                    LOGGER.warning(f"Failed to lookup AniList ID for '{title_val}': {e}")
+            
+            season_val = 1
+            episode_val = abs_ep or 1
+            if abs_ep is not None:
+                mapped = map_tvdb(title_val, abs_ep, anilist_id=anilist_id)
+                if mapped:
+                    season_val, episode_val = mapped
+            
+            parsed_arg = {
+                "title": title_val,
+                "season": season_val,
+                "episode": episode_val,
+                "quality": parsed["quality"],
+                "year": parsed["year"],
+                "absolute_episode": abs_ep
+            }
+            meta_filename = file.file_name or title
+            metadata_info = await metadata(clean_filename(meta_filename), int(channel), msg_id, parsed=parsed_arg)
+        else:
+            metadata_info = await metadata(clean_filename(title), int(channel), msg_id)
+
         if metadata_info is None:
             LOGGER.warning(f"Metadata failed for file: {title} (ID: {msg_id})")
             return
@@ -136,15 +177,51 @@ async def file_edited_handler(client: Client, message: Message):
         if not _is_supported_media(message):
             return
 
-        _, title, msg_id, raw_size, size, channel = _extract_fields(message)
+        file, title, msg_id, raw_size, size, channel = _extract_fields(message)
         override_id = extract_default_id(message.caption) if message.caption else None
         if not override_id:
             return
 
         LOGGER.info(f"Detected override ID '{override_id}' in edited message {msg_id}")
         await db.remove_media_part(int(channel), msg_id)
+        from Backend.helper.metadata import _is_anime_channel
 
-        metadata_info = await metadata(clean_filename(title), int(channel), msg_id, override_id=override_id)
+        if _is_anime_channel(message.chat.id):
+            from Backend.helper.anime_parser import parse_anime_message
+            from Backend.helper.anime_mapping import map_tvdb
+            from Backend.helper.anime import search_anime
+
+            parsed = parse_anime_message(file.file_name, message.caption)
+            title_val = parsed["title"]
+            abs_ep = parsed["absolute_episode"]
+            anilist_id = None
+            if abs_ep is not None and title_val.lower() != "one piece":
+                try:
+                    media_info = await search_anime(title_val)
+                    if media_info:
+                        anilist_id = media_info.get("id")
+                except Exception as e:
+                    LOGGER.warning(f"Failed to lookup AniList ID for '{title_val}': {e}")
+            
+            season_val = 1
+            episode_val = abs_ep or 1
+            if abs_ep is not None:
+                mapped = map_tvdb(title_val, abs_ep, anilist_id=anilist_id)
+                if mapped:
+                    season_val, episode_val = mapped
+            
+            parsed_arg = {
+                "title": title_val,
+                "season": season_val,
+                "episode": episode_val,
+                "quality": parsed["quality"],
+                "year": parsed["year"],
+                "absolute_episode": abs_ep
+            }
+            meta_filename = file.file_name or title
+            metadata_info = await metadata(clean_filename(meta_filename), int(channel), msg_id, override_id=override_id, parsed=parsed_arg)
+        else:
+            metadata_info = await metadata(clean_filename(title), int(channel), msg_id, override_id=override_id)
         if metadata_info is None:
             LOGGER.warning(f"Metadata failed for edited file: {title} (ID: {msg_id})")
             return

--- a/scripts/update_anime_mappings.py
+++ b/scripts/update_anime_mappings.py
@@ -1,0 +1,21 @@
+import urllib.request
+import os
+
+def update_mappings():
+    target_path = os.path.join(os.path.dirname(__file__), "..", "Backend", "helper", "mappings.min.json")
+    target_path = os.path.abspath(target_path)
+    url = "https://github.com/anibridge/anibridge-mappings/releases/download/v3/mappings.min.json"
+    
+    print(f"Downloading latest AniBridge mappings to {target_path}...")
+    try:
+        os.makedirs(os.path.dirname(target_path), exist_ok=True)
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with urllib.request.urlopen(req) as response:
+            with open(target_path, "wb") as f:
+                f.write(response.read())
+        print("AniBridge mappings updated successfully!")
+    except Exception as e:
+        print(f"Failed to update mappings: {e}")
+
+if __name__ == "__main__":
+    update_mappings()


### PR DESCRIPTION
## Summary

This PR improves metadata detection for channels marked as **Anime**, by adding support for absolute episode numbering using the AniBridge mappings project.

It also improves handling of Telegram posts where the caption contains only channel branding while the filename contains the actual media information.

This work uses the mappings provided by:

[https://github.com/anibridge/anibridge-mappings](https://github.com/anibridge/anibridge-mappings)

Thanks to the AniBridge contributors for maintaining these mappings.

---

## Changes

### Added

* `anime_parser.py`

  * Parses anime titles, absolute episode numbers and quality.
  * Merges useful metadata from filename and caption.
  * Prefers filename when captions are decorative.

* `anime_mapping.py`

  * Maps absolute episode numbers to TVDB/TMDB season and episode numbers using AniBridge mappings.

* `mappings.min.json`

  * Vendored AniBridge mappings for offline lookups.

* `scripts/update_anime_mappings.py`

  * Utility script to refresh the mappings from AniBridge when needed.

---

### Updated

**metadata.py**

* Added support for receiving pre-parsed anime metadata.
* Uses mapped TVDB season/episode values while preserving existing metadata flow.
* Keeps existing behaviour for non-anime media.

**receiver.py**

* Uses the new anime parser for anime channels.
* Prefers filename over decorative captions where appropriate.

**scan_manager.py**

* Uses the same parsing and mapping pipeline as live indexing.

**manual_add.py**

* Uses the new anime parser and mapper for manual additions.

---

## Motivation

Many Telegram anime releases use filenames like:

```
1100 One Piece
```

```
One_Piece_EP1168
```

or have decorative captions containing only channel branding.

These formats could previously be parsed incorrectly, resulting in movie matches or incorrect episode metadata.

This PR attempts to improve those cases while keeping the changes isolated to anime channels.

---

## Notes

I created this mainly to solve my own indexing workflow for One Piece.

While the implementation works for my use case, I'm not completely confident that this is the best way to integrate it into the project. If there is a cleaner or more idiomatic approach that fits the existing architecture better, please feel free to modify or refactor it.

Any feedback or suggestions are very welcome, and I'm happy to update the PR if needed.

Thank you for maintaining this project and for taking the time to review this contribution.