### PR TITLE
feat: Add Quality Hierarchy System to prevent quality downgrades on replace

### DIFF
--- a/Backend/helper/database.py
+++ b/Backend/helper/database.py
@@ -1402,6 +1402,28 @@ class Database:
         #----- Incoming is a normal (non-split) file.
         if replace_mode:
             stale = [q for q in existing_qualities if q.get("quality") == target_quality]
+
+            #----- Quality Hierarchy System: only replace if the new file is an actual
+            #----- upgrade (or same quality + smaller size). Prevents e.g. a BluRay/HEVC
+            #----- file being silently deleted and replaced by a weaker x264 re-upload
+            #----- just because both are tagged with the same resolution label.
+            if stale:
+                existing_entry = stale[0]
+                should_replace, reason = QualityChecker.should_replace_quality(
+                    existing_quality_label=existing_entry.get("quality", ""),
+                    existing_quality_name=existing_entry.get("name", ""),
+                    existing_quality_size=existing_entry.get("size", ""),
+                    new_quality_label=quality_to_update.get("quality", ""),
+                    new_quality_name=quality_to_update.get("name", ""),
+                    new_quality_size=quality_to_update.get("size", ""),
+                )
+                if not should_replace:
+                    LOGGER.warning(f"Quality replacement blocked: {reason}")
+                    if status is not None:
+                        status["quality_downgrade_blocked"] = True
+                    return existing_qualities
+                LOGGER.info(f"Quality replacement approved: {reason}")
+
             for q in stale:
                 await self._queue_quality_deletion(q)
             existing_qualities = [

--- a/Backend/helper/database.py
+++ b/Backend/helper/database.py
@@ -16,6 +16,7 @@ from Backend.helper.modal import Episode, MovieSchema, QualityDetail, QualityPar
 from Backend.helper.settings_manager import SettingsManager
 from Backend.helper.task_manager import delete_message
 from Backend.logger import LOGGER
+from Backend.helper.quality_checker import QualityChecker
 
 
 

--- a/Backend/helper/quality_checker.py
+++ b/Backend/helper/quality_checker.py
@@ -1,0 +1,340 @@
+"""
+Quality Hierarchy System for comparing video qualities
+Prevents accidental replacement of high-quality videos with lower quality
+"""
+
+import re
+from typing import Dict, Optional, Tuple
+from Backend.logger import LOGGER
+
+
+class QualityChecker:
+    """
+    Checks and compares video quality based on source, resolution, codec, and audio.
+    Based on real-world torrent quality patterns.
+    """
+
+    # Video Source Quality Rankings (higher = better)
+    SOURCE_RANKINGS = {
+        # Best Quality
+        'bluray': 100, 'blu-ray': 100, 'brrip': 100, 'bdrip': 100,
+        'uhd': 100, '4k': 100,
+
+        # Excellent Quality
+        'web-dl': 85, 'webdl': 85, 'web dl': 85, 'web.dl': 85,  # Added dot variant
+        'webrip': 75, 'web-rip': 75, 'web.rip': 75,  # Added dot variant
+
+        # Streaming Platform WEB-DLs (same quality as generic WEB-DL)
+        'dsnp': 85, 'nf': 85, 'amzn': 85,  # Disney+, Netflix, Amazon (all WEB-DL quality)
+        'atvp': 85, 'aptv': 85,  # Apple TV+
+        'hmax': 85, 'hbo': 85,  # HBO Max
+
+        # Good Quality
+        'dvdrip': 60, 'dvd-rip': 60,
+        'hdrip': 55, 'hd-rip': 55,
+
+        # Decent Quality
+        'hdtv': 50, 'hdtvrip': 50,
+
+        # Lower Quality
+        'dvdscr': 40, 'screener': 40,
+        'r5': 35,
+
+        # Poor Quality
+        'hdcam': 25, 'hd-cam': 25, 'hdts': 25, 'hd-ts': 25,
+        'cam': 15, 'camrip': 15, 'cam-rip': 15,
+        'ts': 15, 'telesync': 15, 'tc': 15, 'telecine': 15,
+
+        # Worst Quality
+        'predvd': 10, 'workprint': 10, 'ppv': 10, 'vhsrip': 5
+    }
+
+    # Video Codec Rankings (higher = better)
+    CODEC_RANKINGS = {
+        'h265': 20, 'hevc': 20, 'x265': 20, 'h.265': 20,
+        'av1': 18,
+        'h264': 15, 'x264': 15, 'h.264': 15, 'avc': 15,
+        'vp9': 12,
+        'xvid': 8,
+        'divx': 5,
+        'mpeg': 3
+    }
+
+    # Audio Quality Rankings (higher = better)
+    AUDIO_RANKINGS = {
+        'atmos': 100, 'dolby atmos': 100,
+        'truehd': 95, 'dts-hd': 95, 'dts-hd ma': 95,
+        'ddp': 90, 'dd+': 90, 'eac3': 90,
+        'dts': 85, 'dts-x': 88,
+        'dd5.1': 80, 'dd 5.1': 80, 'ac3': 80, 'dolby digital': 80,
+        'ddp5.1': 85, 'dd+5.1': 85,
+        'aac5.1': 65, 'aac 5.1': 65,
+        'opus': 60,
+        'aac2.0': 50, 'aac 2.0': 50, 'aac': 50,
+        'mp3': 40,
+        'stereo': 35, '2.0': 35,
+        'mono': 20
+    }
+
+    # Resolution Rankings (higher = better)
+    RESOLUTION_RANKINGS = {
+        '2160p': 100, '4k': 100, 'uhd': 100,
+        '1440p': 80, '2k': 80,
+        '1080p': 70, 'fhd': 70,
+        '720p': 50, 'hd': 50,
+        '576p': 35,
+        '480p': 30, 'sd': 30,
+        '360p': 20,
+        '240p': 10
+    }
+
+    # HDR/Color Rankings (bonus points)
+    HDR_RANKINGS = {
+        'hdr10+': 15, 'hdr10plus': 15,
+        'hdr10': 12, 'hdr': 12,
+        'dolby vision': 18, 'dv': 18,
+        'hlg': 10,
+        'sdr': 0
+    }
+
+    @staticmethod
+    def parse_filename(filename: str) -> Dict[str, any]:
+        """
+        Parse filename to extract quality indicators.
+        Returns dict with source, codec, audio, resolution, hdr, etc.
+        """
+        filename_lower = filename.lower()
+
+        result = {
+            'source': None,
+            'source_score': 0,
+            'codec': None,
+            'codec_score': 0,
+            'audio': None,
+            'audio_score': 0,
+            'resolution': None,
+            'resolution_score': 0,
+            'hdr': None,
+            'hdr_score': 0,
+            'is_10bit': '10bit' in filename_lower or '10-bit' in filename_lower,
+            'bitrate_bonus': 0
+        }
+
+        # Find video source
+        for source, score in QualityChecker.SOURCE_RANKINGS.items():
+            if source in filename_lower:
+                if score > result['source_score']:
+                    result['source'] = source
+                    result['source_score'] = score
+
+        # Find codec
+        for codec, score in QualityChecker.CODEC_RANKINGS.items():
+            if codec in filename_lower:
+                if score > result['codec_score']:
+                    result['codec'] = codec
+                    result['codec_score'] = score
+
+        # Find audio
+        for audio, score in QualityChecker.AUDIO_RANKINGS.items():
+            if audio in filename_lower:
+                if score > result['audio_score']:
+                    result['audio'] = audio
+                    result['audio_score'] = score
+
+        # Find resolution
+        for resolution, score in QualityChecker.RESOLUTION_RANKINGS.items():
+            if resolution in filename_lower:
+                if score > result['resolution_score']:
+                    result['resolution'] = resolution
+                    result['resolution_score'] = score
+
+        # Find HDR
+        for hdr, score in QualityChecker.HDR_RANKINGS.items():
+            if hdr in filename_lower:
+                if score > result['hdr_score']:
+                    result['hdr'] = hdr
+                    result['hdr_score'] = score
+
+        # 10-bit bonus
+        if result['is_10bit']:
+            result['bitrate_bonus'] = 5
+
+        # Default audio assumption for high-quality sources without explicit audio info
+        # This prevents WEB-DL/BluRay from losing to lower sources just because audio isn't in filename
+        if result['audio_score'] == 0:
+            # High-quality sources typically have at least DD5.1 or better
+            if result['source'] in ['bluray', 'blu-ray', 'brrip', 'bdrip', 'uhd', '4k']:
+                result['audio'] = 'assumed-dd5.1'
+                result['audio_score'] = 80  # Assume standard DD5.1 for BluRay
+            elif result['source'] in ['web-dl', 'webdl', 'web dl', 'web.dl', 'dsnp', 'nf', 'amzn', 'atvp', 'aptv', 'hmax', 'hbo']:
+                result['audio'] = 'assumed-ddp'
+                result['audio_score'] = 85  # Streaming platforms typically use DD+ (EAC3)
+            elif result['source'] in ['webrip', 'web-rip', 'web.rip']:
+                result['audio'] = 'assumed-stereo'
+                result['audio_score'] = 45  # Conservative assumption for WEBRip
+
+        return result
+
+    @staticmethod
+    def calculate_total_score(parsed_quality: Dict) -> int:
+        """
+        Calculate total quality score from parsed quality data.
+        """
+        total = (
+            parsed_quality['source_score'] +
+            parsed_quality['codec_score'] +
+            parsed_quality['audio_score'] +
+            parsed_quality['resolution_score'] +
+            parsed_quality['hdr_score'] +
+            parsed_quality['bitrate_bonus']
+        )
+        return total
+
+    @staticmethod
+    def parse_file_size(size_str: str) -> float:
+        """
+        Parse file size string to MB.
+        Examples: "2.5GB", "1500MB", "1.5 GB"
+        """
+        if not size_str:
+            return 0.0
+
+        size_str = size_str.upper().replace(' ', '')
+
+        # Extract number
+        match = re.search(r'([\d.]+)', size_str)
+        if not match:
+            return 0.0
+
+        size = float(match.group(1))
+
+        # Convert to MB
+        if 'GB' in size_str:
+            size *= 1024
+        elif 'TB' in size_str:
+            size *= 1024 * 1024
+        elif 'KB' in size_str:
+            size /= 1024
+
+        return size
+
+    @staticmethod
+    def compare_quality(
+        existing_filename: str,
+        existing_size: str,
+        new_filename: str,
+        new_size: str
+    ) -> Tuple[bool, str]:
+        """
+        Compare two video qualities.
+
+        Returns:
+            (should_replace: bool, reason: str)
+
+        Logic:
+        1. If new quality score > existing: REPLACE (better quality)
+        2. If scores equal but new size < existing: REPLACE (same quality, smaller file)
+        3. If new quality score < existing: DON'T REPLACE (worse quality)
+        """
+        # Parse both files
+        existing_quality = QualityChecker.parse_filename(existing_filename)
+        new_quality = QualityChecker.parse_filename(new_filename)
+
+        # Calculate scores
+        existing_score = QualityChecker.calculate_total_score(existing_quality)
+        new_score = QualityChecker.calculate_total_score(new_quality)
+
+        # Parse file sizes
+        existing_size_mb = QualityChecker.parse_file_size(existing_size)
+        new_size_mb = QualityChecker.parse_file_size(new_size)
+
+        # Log comparison
+        LOGGER.info(f"Quality Comparison:")
+        LOGGER.info(f"  Existing: {existing_filename}")
+        LOGGER.info(f"    Score: {existing_score} (source:{existing_quality['source_score']}, "
+                   f"codec:{existing_quality['codec_score']}, audio:{existing_quality['audio_score']}, "
+                   f"res:{existing_quality['resolution_score']}, hdr:{existing_quality['hdr_score']})")
+        LOGGER.info(f"    Size: {existing_size} ({existing_size_mb:.2f} MB)")
+        LOGGER.info(f"  New: {new_filename}")
+        LOGGER.info(f"    Score: {new_score} (source:{new_quality['source_score']}, "
+                   f"codec:{new_quality['codec_score']}, audio:{new_quality['audio_score']}, "
+                   f"res:{new_quality['resolution_score']}, hdr:{new_quality['hdr_score']})")
+        LOGGER.info(f"    Size: {new_size} ({new_size_mb:.2f} MB)")
+
+        # Decision logic
+        if new_score > existing_score:
+            reason = (f"✅ REPLACE - Better quality "
+                     f"(score: {new_score} > {existing_score})")
+            LOGGER.info(f"  Decision: {reason}")
+            return True, reason
+
+        elif new_score == existing_score:
+            # Same quality - prefer smaller file
+            if new_size_mb > 0 and existing_size_mb > 0:
+                if new_size_mb < existing_size_mb:
+                    size_diff = existing_size_mb - new_size_mb
+                    reason = (f"✅ REPLACE - Same quality, smaller file "
+                             f"({new_size_mb:.2f}MB < {existing_size_mb:.2f}MB, saves {size_diff:.2f}MB)")
+                    LOGGER.info(f"  Decision: {reason}")
+                    return True, reason
+                else:
+                    reason = (f"⏭️ SKIP - Same quality, but larger file "
+                             f"({new_size_mb:.2f}MB > {existing_size_mb:.2f}MB)")
+                    LOGGER.info(f"  Decision: {reason}")
+                    return False, reason
+            else:
+                # Can't compare size, allow replacement
+                reason = f"✅ REPLACE - Same quality, size unknown"
+                LOGGER.info(f"  Decision: {reason}")
+                return True, reason
+
+        else:  # new_score < existing_score
+            reason = (f"❌ SKIP - Lower quality detected! "
+                     f"(score: {new_score} < {existing_score})\n"
+                     f"Existing: {existing_quality['source'] or 'unknown'} "
+                     f"{existing_quality['resolution'] or ''} "
+                     f"{existing_quality['codec'] or ''} "
+                     f"{existing_quality['audio'] or ''}\n"
+                     f"New: {new_quality['source'] or 'unknown'} "
+                     f"{new_quality['resolution'] or ''} "
+                     f"{new_quality['codec'] or ''} "
+                     f"{new_quality['audio'] or ''}")
+            LOGGER.warning(f"  Decision: {reason}")
+            return False, reason
+
+    @staticmethod
+    def should_replace_quality(
+        existing_quality_label: str,
+        existing_quality_name: str,
+        existing_quality_size: str,
+        new_quality_label: str,
+        new_quality_name: str,
+        new_quality_size: str
+    ) -> Tuple[bool, str]:
+        """
+        Main entry point for quality comparison.
+
+        Args:
+            existing_quality_label: Resolution label like "1080p", "720p"
+            existing_quality_name: Full filename
+            existing_quality_size: File size string like "2.5GB"
+            new_quality_label: Resolution label
+            new_quality_name: Full filename
+            new_quality_size: File size string
+
+        Returns:
+            (should_replace: bool, reason: str)
+        """
+        # If different resolution labels, use old logic (always replace)
+        if existing_quality_label != new_quality_label:
+            reason = f"Different resolution ({existing_quality_label} vs {new_quality_label}) - using default replacement"
+            LOGGER.info(reason)
+            return True, reason
+
+        # Same resolution label - use quality hierarchy
+        return QualityChecker.compare_quality(
+            existing_quality_name,
+            existing_quality_size,
+            new_quality_name,
+            new_quality_size
+        )

--- a/Backend/tests/test_quality_checker.py
+++ b/Backend/tests/test_quality_checker.py
@@ -1,0 +1,202 @@
+"""
+Test cases for Quality Hierarchy System
+Run with: uv run python -m pytest Backend/tests/test_quality_checker.py -v
+"""
+
+import pytest
+from Backend.helper.quality_checker import QualityChecker
+
+
+class TestQualityChecker:
+    """Test Quality Hierarchy System"""
+    
+    def test_bluray_vs_hdcam_same_resolution(self):
+        """BluRay should always beat HDCam even at same resolution"""
+        should_replace, reason = QualityChecker.compare_quality(
+            existing_filename="Movie.2023.1080p.BluRay.DD5.1.mkv",
+            existing_size="3.2GB",
+            new_filename="Movie.2023.1080p.HDCam.AAC.2.0.mkv",
+            new_size="1.5GB"
+        )
+        assert should_replace == False, "Should NOT replace BluRay with HDCam"
+        assert "Lower quality" in reason
+    
+    def test_hdcam_to_bluray_upgrade(self):
+        """HDCam should be replaced by BluRay"""
+        should_replace, reason = QualityChecker.compare_quality(
+            existing_filename="Movie.2023.1080p.HDCam.AAC.2.0.mkv",
+            existing_size="1.5GB",
+            new_filename="Movie.2023.1080p.BluRay.DD5.1.mkv",
+            new_size="3.2GB"
+        )
+        assert should_replace == True, "Should replace HDCam with BluRay"
+        assert "Better quality" in reason
+    
+    def test_web_dl_vs_webrip(self):
+        """WEB-DL should be preferred over WEBRip"""
+        should_replace, reason = QualityChecker.compare_quality(
+            existing_filename="Movie.2023.1080p.WEB-DL.DD5.1.mkv",
+            existing_size="2.8GB",
+            new_filename="Movie.2023.1080p.WEBRip.AAC.2.0.mkv",
+            new_size="2.0GB"
+        )
+        assert should_replace == False, "Should NOT replace WEB-DL with WEBRip"
+    
+    def test_same_quality_prefer_smaller_size(self):
+        """Same quality - prefer HEVC smaller file"""
+        should_replace, reason = QualityChecker.compare_quality(
+            existing_filename="Movie.2023.1080p.BluRay.x264.DD5.1.mkv",
+            existing_size="3.5GB",
+            new_filename="Movie.2023.1080p.BluRay.x265.HEVC.DD5.1.mkv",
+            new_size="2.1GB"
+        )
+        assert should_replace == True, "Should replace with smaller file"
+        assert "smaller file" in reason.lower()
+    
+    def test_same_quality_reject_larger_size(self):
+        """Same quality - reject larger file"""
+        should_replace, reason = QualityChecker.compare_quality(
+            existing_filename="Movie.2023.1080p.BluRay.x265.HEVC.DD5.1.mkv",
+            existing_size="2.1GB",
+            new_filename="Movie.2023.1080p.BluRay.x264.DD5.1.mkv",
+            new_size="3.5GB"
+        )
+        assert should_replace == False, "Should NOT replace with larger file"
+        assert "larger file" in reason.lower()
+    
+    def test_dd5_1_vs_aac(self):
+        """DD5.1 audio should beat AAC 2.0"""
+        should_replace, reason = QualityChecker.compare_quality(
+            existing_filename="Movie.2023.1080p.BluRay.DD5.1.mkv",
+            existing_size="3GB",
+            new_filename="Movie.2023.1080p.BluRay.AAC.2.0.mkv",
+            new_size="2.5GB"
+        )
+        assert should_replace == False, "Should NOT downgrade audio quality"
+    
+    def test_hdr_bonus(self):
+        """HDR10 should add bonus points"""
+        should_replace, reason = QualityChecker.compare_quality(
+            existing_filename="Movie.2023.1080p.WEB-DL.AAC.mkv",
+            existing_size="2.5GB",
+            new_filename="Movie.2023.1080p.WEB-DL.HDR10.AAC.mkv",
+            new_size="2.5GB"
+        )
+        assert should_replace == True, "HDR version should win"
+    
+    def test_10bit_bonus(self):
+        """10-bit encoding should add bonus"""
+        should_replace, reason = QualityChecker.compare_quality(
+            existing_filename="Movie.2023.1080p.WEB-DL.x264.mkv",
+            existing_size="2.5GB",
+            new_filename="Movie.2023.1080p.WEB-DL.x264.10bit.mkv",
+            new_size="2.5GB"
+        )
+        assert should_replace == True, "10-bit version should win"
+    
+    def test_different_resolution_always_replace(self):
+        """Different resolutions should use default logic"""
+        should_replace, reason = QualityChecker.should_replace_quality(
+            existing_quality_label="720p",
+            existing_quality_name="Movie.2023.720p.BluRay.mkv",
+            existing_quality_size="2GB",
+            new_quality_label="1080p",
+            new_quality_name="Movie.2023.1080p.HDCam.mkv",
+            new_quality_size="1.5GB"
+        )
+        assert should_replace == True, "Different resolutions use default logic"
+        assert "Different resolution" in reason
+    
+    def test_filename_parsing_complex(self):
+        """Test parsing complex real-world filename"""
+        parsed = QualityChecker.parse_filename(
+            "Avengers.Endgame.2019.1080p.BluRay.x265.10bit.DD5.1.HEVC-Galaxy"
+        )
+        assert parsed['source'] == 'bluray'
+        assert parsed['codec'] in ['x265', 'hevc']
+        assert parsed['resolution'] == '1080p'
+        assert parsed['is_10bit'] == True
+        assert 'dd5.1' in parsed['audio'] or 'dd 5.1' in parsed['audio']
+    
+    def test_size_parsing(self):
+        """Test file size parsing"""
+        assert QualityChecker.parse_file_size("2.5GB") == pytest.approx(2560, rel=1)
+        assert QualityChecker.parse_file_size("1500MB") == pytest.approx(1500, rel=1)
+        assert QualityChecker.parse_file_size("3.2 GB") == pytest.approx(3276.8, rel=1)
+        assert QualityChecker.parse_file_size("500KB") == pytest.approx(0.488, rel=0.1)
+    
+    def test_real_world_scenario_1(self):
+        """Test based on user's Avengers Endgame example"""
+        # Good BluRay DD5.1 vs HDCam AAC
+        should_replace, reason = QualityChecker.compare_quality(
+            existing_filename="Avengers.Endgame.2019.1080p.BluRay.DD5.1.x265.10bit-Galaxy",
+            existing_size="3.0GB",
+            new_filename="Avengers.Endgame.2019.1080p.HDCam.AAC.2.0.mkv",
+            new_size="2.1GB"
+        )
+        assert should_replace == False, "Must NOT replace BluRay with HDCam"
+    
+    def test_real_world_scenario_2(self):
+        """Test upgrading from WEBRip to BluRay"""
+        should_replace, reason = QualityChecker.compare_quality(
+            existing_filename="Movie.2023.1080p.WEBRip.x264.AAC.mkv",
+            existing_size="2.5GB",
+            new_filename="Movie.2023.1080p.BluRay.x265.DD5.1.10bit.mkv",
+            new_size="2.8GB"
+        )
+        assert should_replace == True, "Should upgrade WEBRip to BluRay"
+    
+    def test_platform_sources(self):
+        """Test streaming platform sources (DSNP, AMZN, NF)"""
+        should_replace, reason = QualityChecker.compare_quality(
+            existing_filename="Movie.2023.1080p.DSNP.WEB-DL.DD5.1.mkv",
+            existing_size="3GB",
+            new_filename="Movie.2023.1080p.HDRip.AAC.mkv",
+            new_size="2GB"
+        )
+        assert should_replace == False, "DSNP WEB-DL should beat HDRip"
+
+
+if __name__ == "__main__":
+    # Run tests manually
+    test = TestQualityChecker()
+    
+    print("Running Quality Hierarchy Tests...\n")
+    
+    tests = [
+        ("BluRay vs HDCam", test.test_bluray_vs_hdcam_same_resolution),
+        ("HDCam to BluRay upgrade", test.test_hdcam_to_bluray_upgrade),
+        ("WEB-DL vs WEBRip", test.test_web_dl_vs_webrip),
+        ("Same quality prefer smaller", test.test_same_quality_prefer_smaller_size),
+        ("Same quality reject larger", test.test_same_quality_reject_larger_size),
+        ("DD5.1 vs AAC", test.test_dd5_1_vs_aac),
+        ("HDR bonus", test.test_hdr_bonus),
+        ("10-bit bonus", test.test_10bit_bonus),
+        ("Different resolution", test.test_different_resolution_always_replace),
+        ("Complex filename parsing", test.test_filename_parsing_complex),
+        ("Size parsing", test.test_size_parsing),
+        ("Real-world scenario 1", test.test_real_world_scenario_1),
+        ("Real-world scenario 2", test.test_real_world_scenario_2),
+        ("Platform sources", test.test_platform_sources),
+    ]
+    
+    passed = 0
+    failed = 0
+    
+    for name, test_func in tests:
+        try:
+            test_func()
+            print(f"✅ PASS: {name}")
+            passed += 1
+        except AssertionError as e:
+            print(f"❌ FAIL: {name}")
+            print(f"   Error: {e}\n")
+            failed += 1
+        except Exception as e:
+            print(f"❌ ERROR: {name}")
+            print(f"   Error: {e}\n")
+            failed += 1
+    
+    print(f"\n{'='*50}")
+    print(f"Results: {passed} passed, {failed} failed")
+    print(f"{'='*50}")

--- a/Backend/tests/test_quality_standalone.py
+++ b/Backend/tests/test_quality_standalone.py
@@ -1,0 +1,301 @@
+"""
+Standalone Quality Checker Test
+Run directly without full Backend imports
+"""
+
+import sys
+import re
+from typing import Dict, Tuple
+
+
+class QualityChecker:
+    """Quality comparison system"""
+    
+    SOURCE_RANKINGS = {
+        'bluray': 100, 'blu-ray': 100, 'brrip': 100, 'bdrip': 100,
+        'uhd': 100, '4k': 100,
+        'web-dl': 85, 'webdl': 85, 'web dl': 85, 'web.dl': 85,
+        'webrip': 75, 'web-rip': 75, 'web.rip': 75,
+        'dsnp': 85, 'nf': 85, 'amzn': 85,
+        'atvp': 85, 'aptv': 85, 'hmax': 85, 'hbo': 85,
+        'dvdrip': 60, 'dvd-rip': 60,
+        'hdrip': 55, 'hd-rip': 55,
+        'hdtv': 50, 'hdtvrip': 50,
+        'dvdscr': 40, 'screener': 40,
+        'r5': 35,
+        'hdcam': 25, 'hd-cam': 25, 'hdts': 25, 'hd-ts': 25,
+        'cam': 15, 'camrip': 15, 'cam-rip': 15,
+        'ts': 15, 'telesync': 15, 'tc': 15, 'telecine': 15,
+        'predvd': 10, 'workprint': 10, 'ppv': 10, 'vhsrip': 5
+    }
+    
+    CODEC_RANKINGS = {
+        'h265': 20, 'hevc': 20, 'x265': 20, 'h.265': 20,
+        'av1': 18,
+        'h264': 15, 'x264': 15, 'h.264': 15, 'avc': 15,
+        'vp9': 12, 'xvid': 8, 'divx': 5, 'mpeg': 3
+    }
+    
+    AUDIO_RANKINGS = {
+        'atmos': 100, 'dolby atmos': 100,
+        'truehd': 95, 'dts-hd': 95, 'dts-hd ma': 95,
+        'ddp': 90, 'dd+': 90, 'eac3': 90,
+        'dts': 85, 'dts-x': 88,
+        'dd5.1': 80, 'dd 5.1': 80, 'ac3': 80, 'dolby digital': 80,
+        'ddp5.1': 85, 'dd+5.1': 85,
+        'aac5.1': 65, 'aac 5.1': 65,
+        'opus': 60,
+        'aac2.0': 50, 'aac 2.0': 50, 'aac': 50,
+        'mp3': 40, 'stereo': 35, '2.0': 35, 'mono': 20
+    }
+    
+    RESOLUTION_RANKINGS = {
+        '2160p': 100, '4k': 100, 'uhd': 100,
+        '1440p': 80, '2k': 80,
+        '1080p': 70, 'fhd': 70,
+        '720p': 50, 'hd': 50,
+        '576p': 35, '480p': 30, 'sd': 30,
+        '360p': 20, '240p': 10
+    }
+    
+    HDR_RANKINGS = {
+        'hdr10+': 15, 'hdr10plus': 15,
+        'hdr10': 12, 'hdr': 12,
+        'dolby vision': 18, 'dv': 18,
+        'hlg': 10, 'sdr': 0
+    }
+    
+    @staticmethod
+    def parse_filename(filename: str) -> Dict:
+        filename_lower = filename.lower()
+        result = {
+            'source': None, 'source_score': 0,
+            'codec': None, 'codec_score': 0,
+            'audio': None, 'audio_score': 0,
+            'resolution': None, 'resolution_score': 0,
+            'hdr': None, 'hdr_score': 0,
+            'is_10bit': '10bit' in filename_lower or '10-bit' in filename_lower,
+            'bitrate_bonus': 0
+        }
+        
+        for source, score in QualityChecker.SOURCE_RANKINGS.items():
+            if source in filename_lower:
+                if score > result['source_score']:
+                    result['source'] = source
+                    result['source_score'] = score
+        
+        for codec, score in QualityChecker.CODEC_RANKINGS.items():
+            if codec in filename_lower:
+                if score > result['codec_score']:
+                    result['codec'] = codec
+                    result['codec_score'] = score
+        
+        for audio, score in QualityChecker.AUDIO_RANKINGS.items():
+            if audio in filename_lower:
+                if score > result['audio_score']:
+                    result['audio'] = audio
+                    result['audio_score'] = score
+        
+        for resolution, score in QualityChecker.RESOLUTION_RANKINGS.items():
+            if resolution in filename_lower:
+                if score > result['resolution_score']:
+                    result['resolution'] = resolution
+                    result['resolution_score'] = score
+        
+        for hdr, score in QualityChecker.HDR_RANKINGS.items():
+            if hdr in filename_lower:
+                if score > result['hdr_score']:
+                    result['hdr'] = hdr
+                    result['hdr_score'] = score
+        
+        if result['is_10bit']:
+            result['bitrate_bonus'] = 5
+        
+        # Default audio assumption for high-quality sources without explicit audio info
+        if result['audio_score'] == 0:
+            if result['source'] in ['bluray', 'blu-ray', 'brrip', 'bdrip', 'uhd', '4k']:
+                result['audio'] = 'assumed-dd5.1'
+                result['audio_score'] = 80
+            elif result['source'] in ['web-dl', 'webdl', 'web dl', 'web.dl', 'dsnp', 'nf', 'amzn', 'atvp', 'aptv', 'hmax', 'hbo']:
+                result['audio'] = 'assumed-ddp'
+                result['audio_score'] = 85
+            elif result['source'] in ['webrip', 'web-rip', 'web.rip']:
+                result['audio'] = 'assumed-stereo'
+                result['audio_score'] = 45
+        
+        return result
+    
+    @staticmethod
+    def calculate_total_score(parsed_quality: Dict) -> int:
+        return (
+            parsed_quality['source_score'] +
+            parsed_quality['codec_score'] +
+            parsed_quality['audio_score'] +
+            parsed_quality['resolution_score'] +
+            parsed_quality['hdr_score'] +
+            parsed_quality['bitrate_bonus']
+        )
+    
+    @staticmethod
+    def parse_file_size(size_str: str) -> float:
+        if not size_str:
+            return 0.0
+        size_str = size_str.upper().replace(' ', '')
+        match = re.search(r'([\d.]+)', size_str)
+        if not match:
+            return 0.0
+        size = float(match.group(1))
+        if 'GB' in size_str:
+            size *= 1024
+        elif 'TB' in size_str:
+            size *= 1024 * 1024
+        elif 'KB' in size_str:
+            size /= 1024
+        return size
+    
+    @staticmethod
+    def compare_quality(existing_filename: str, existing_size: str,
+                       new_filename: str, new_size: str) -> Tuple[bool, str]:
+        existing_quality = QualityChecker.parse_filename(existing_filename)
+        new_quality = QualityChecker.parse_filename(new_filename)
+        
+        existing_score = QualityChecker.calculate_total_score(existing_quality)
+        new_score = QualityChecker.calculate_total_score(new_quality)
+        
+        existing_size_mb = QualityChecker.parse_file_size(existing_size)
+        new_size_mb = QualityChecker.parse_file_size(new_size)
+        
+        print(f"\n  Existing: {existing_filename}")
+        print(f"    Score: {existing_score} (source:{existing_quality['source_score']}, "
+              f"codec:{existing_quality['codec_score']}, audio:{existing_quality['audio_score']}, "
+              f"res:{existing_quality['resolution_score']}, hdr:{existing_quality['hdr_score']})")
+        print(f"    Size: {existing_size} ({existing_size_mb:.2f} MB)")
+        print(f"  New: {new_filename}")
+        print(f"    Score: {new_score} (source:{new_quality['source_score']}, "
+              f"codec:{new_quality['codec_score']}, audio:{new_quality['audio_score']}, "
+              f"res:{new_quality['resolution_score']}, hdr:{new_quality['hdr_score']})")
+        print(f"    Size: {new_size} ({new_size_mb:.2f} MB)")
+        
+        if new_score > existing_score:
+            reason = f"✅ REPLACE - Better quality (score: {new_score} > {existing_score})"
+            return True, reason
+        elif new_score == existing_score:
+            if new_size_mb > 0 and existing_size_mb > 0:
+                if new_size_mb < existing_size_mb:
+                    size_diff = existing_size_mb - new_size_mb
+                    reason = f"✅ REPLACE - Same quality, smaller file (saves {size_diff:.2f}MB)"
+                    return True, reason
+                else:
+                    reason = f"⏭️ SKIP - Same quality, but larger file"
+                    return False, reason
+            else:
+                reason = f"✅ REPLACE - Same quality, size unknown"
+                return True, reason
+        else:
+            reason = f"❌ SKIP - Lower quality (score: {new_score} < {existing_score})"
+            return False, reason
+
+
+# Test Cases
+def run_tests():
+    tests = [
+        {
+            'name': 'BluRay vs HDCam (same resolution)',
+            'existing': ('Movie.2023.1080p.BluRay.DD5.1.mkv', '3.2GB'),
+            'new': ('Movie.2023.1080p.HDCam.AAC.2.0.mkv', '1.5GB'),
+            'expected': False,
+            'reason': 'Must NOT replace BluRay with HDCam'
+        },
+        {
+            'name': 'HDCam to BluRay upgrade',
+            'existing': ('Movie.2023.1080p.HDCam.AAC.2.0.mkv', '1.5GB'),
+            'new': ('Movie.2023.1080p.BluRay.DD5.1.mkv', '3.2GB'),
+            'expected': True,
+            'reason': 'Should upgrade from HDCam to BluRay'
+        },
+        {
+            'name': 'Same quality, prefer smaller HEVC',
+            'existing': ('Movie.2023.1080p.BluRay.x264.DD5.1.mkv', '3.5GB'),
+            'new': ('Movie.2023.1080p.BluRay.x265.HEVC.DD5.1.mkv', '2.1GB'),
+            'expected': True,
+            'reason': 'Should prefer smaller file with same quality'
+        },
+        {
+            'name': 'Same quality, reject larger file',
+            'existing': ('Movie.2023.1080p.BluRay.x265.HEVC.DD5.1.mkv', '2.1GB'),
+            'new': ('Movie.2023.1080p.BluRay.x264.DD5.1.mkv', '3.5GB'),
+            'expected': False,
+            'reason': 'Should reject larger file with same quality'
+        },
+        {
+            'name': 'WEB-DL vs WEBRip',
+            'existing': ('Movie.2023.1080p.WEB-DL.DD5.1.mkv', '2.8GB'),
+            'new': ('Movie.2023.1080p.WEBRip.AAC.2.0.mkv', '2.0GB'),
+            'expected': False,
+            'reason': 'WEB-DL should beat WEBRip'
+        },
+        {
+            'name': 'Real-world: Avengers BluRay vs HDCam',
+            'existing': ('Avengers.Endgame.2019.1080p.BluRay.DD5.1.x265.10bit-Galaxy', '3.0GB'),
+            'new': ('Avengers.Endgame.2019.1080p.HDCam.AAC.2.0.mkv', '2.1GB'),
+            'expected': False,
+            'reason': 'Must protect high-quality BluRay from HDCam replacement'
+        },
+        {
+            'name': 'Real-world: WEBRip DDP5.1 vs WEB-DL (no audio in filename)',
+            'existing': ('Mission.Impossible.The.Final.Reckoning.2025.1080p.WEBRip.DDP5.1.x265-NeoNoir.mkv', '2.80GB'),
+            'new': ('Mission Impossible The Final Reckoning 2025 IMAX 1080p WEB-DL HEVC x265-RMTeam.mkv', '2.87GB'),
+            'expected': True,
+            'reason': 'WEB-DL should replace WEBRip even without explicit audio (assumes DD5.1)'
+        },
+        {
+            'name': 'Real-world: WEB-DL vs AMZN WEB-DL (dot separator)',
+            'existing': ('The.Conjuring.Last.Rites.2025.WebDl.Rip.1080p.H265.AC3.mkv', '2.35GB'),
+            'new': ('The.Conjuring.Last.Rites.2025.1080p.HEVC.AMZN.WEB.DL.Multi.H.265.mkv', '3.25GB'),
+            'expected': True,
+            'reason': 'AMZN WEB.DL (with dots) should be detected and replace WebDl Rip'
+        },
+        {
+            'name': 'Real-world: WEBRip vs web.dl (lowercase with dots)',
+            'existing': ('Dangerous.Animals.2025.1080p.WEBRip.DDP5.1.x265-NeoNoir.mkv', '1.62GB'),
+            'new': ('dangerous.animals.2025.1080p.web.dl.hevc.x265.rmteam.mkv', '1.20GB'),
+            'expected': True,
+            'reason': 'web.dl (lowercase with dots) should be detected as WEB-DL and replace WEBRip'
+        },
+    ]
+    
+    print("\n" + "="*70)
+    print("QUALITY HIERARCHY SYSTEM - TEST RESULTS")
+    print("="*70)
+    
+    passed = 0
+    failed = 0
+    
+    for test in tests:
+        print(f"\n🧪 Test: {test['name']}")
+        print(f"Expected: {'REPLACE' if test['expected'] else 'SKIP'} - {test['reason']}")
+        
+        should_replace, reason = QualityChecker.compare_quality(
+            test['existing'][0], test['existing'][1],
+            test['new'][0], test['new'][1]
+        )
+        
+        print(f"  Result: {reason}")
+        
+        if should_replace == test['expected']:
+            print(f"  ✅ PASS")
+            passed += 1
+        else:
+            print(f"  ❌ FAIL - Expected {test['expected']}, got {should_replace}")
+            failed += 1
+    
+    print("\n" + "="*70)
+    print(f"FINAL RESULTS: {passed} PASSED, {failed} FAILED")
+    print("="*70 + "\n")
+    
+    return failed == 0
+
+
+if __name__ == "__main__":
+    success = run_tests()
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
### Summary

This PR adds a **Quality Hierarchy System** that prevents high-quality video files from being accidentally overwritten by lower-quality versions during database updates.

**Problem:** When the bot scans new Telegram files and updates the database, the existing logic replaced any file matching the same resolution label unconditionally — regardless of whether the incoming file was actually better or worse. A BluRay 1080p entry could be silently overwritten by an HDCam/CAM rip of the same resolution.

**Solution:** A new `QualityChecker` module parses filenames to extract quality signals and computes a weighted score, then only allows replacement when it's a genuine upgrade (or an equal-quality, smaller file).

### How it works

`Backend/helper/quality_checker.py` — new module, no external dependencies beyond the project's own logger.

1. **`parse_filename()`** extracts and scores five signals from the filename (case-insensitive substring match against ranking tables):
   - Source: BluRay/UHD (100) → WEB-DL (85) → WEBRip (75) → DVDRip/HDTV (35–60) → Screener/R5 (35–40) → HDCam/CAM/TS (15–25) → PreDVD/VHSRip (5–10)
   - Codec: H.265/HEVC (20) → AV1 (18) → H.264/AVC (15) → VP9 (12) → Xvid/DivX (5–8)
   - Audio: Atmos/TrueHD (95–100) → DTS-HD/DD+ (85–95) → DD5.1/AC3 (80) → AAC 5.1 (65) → AAC 2.0 (50) → MP3/Stereo/Mono (20–40)
   - Resolution: 2160p/4K (100) → 1440p (80) → 1080p (70) → 720p (50) → 480p (30) → 360p/240p (10–20)
   - HDR: Dolby Vision (18) → HDR10+ (15) → HDR10 (12) → HLG (10)
   - +5 bonus for 10-bit encoding.
   - If no audio tag is found, a conservative assumption is applied based on source (BluRay → DD5.1 ≈80, WEB-DL/streaming platforms → DD+/EAC3 ≈85, WEBRip → stereo ≈45), so a good source isn't unfairly penalized just for missing an explicit audio tag in the filename.

2. **`calculate_total_score()`** sums all category scores into one number.

3. **`compare_quality(existing_filename, existing_size, new_filename, new_size)`** — the core decision function:
   - `new_score > existing_score` → **replace** (quality upgrade)
   - `new_score == existing_score` and `new_size < existing_size` → **replace** (same quality, smaller file — storage saving)
   - `new_score == existing_score` and size unknown → **replace** (can't compare, default to allow)
   - `new_score < existing_score` → **skip** (protects the better existing file)
   - Every comparison is logged with the full score breakdown (`source:`, `codec:`, `audio:`, `res:`, `hdr:`) for auditability.

4. **`should_replace_quality(...)`** is the public entry point. It first checks whether the existing and incoming entries have the *same* resolution label. If resolutions differ (e.g. 720p vs 1080p), it falls back to the original always-replace behavior — this system only changes behavior for same-resolution replacement decisions, so existing behavior for resolution upgrades/downgrades is untouched.

### Integration points

- **`Backend/helper/database.py` → `update_movie()`**: when a quality entry with a matching resolution label already exists, `QualityChecker.should_replace_quality()` is called before overwriting. On approval, the old Telegram message is queued for deletion (`delete_message`) and the entry is updated; on rejection, the function returns early and nothing changes.
- **`Backend/helper/database.py` → `update_tv_show()`**: identical logic applied per-episode inside the season/episode update loop.

### Testing

- `Backend/tests/test_quality_checker.py` — pytest suite covering: BluRay vs HDCam protection, upgrade scenarios, same-quality/smaller-size (HEVC) preference, WEB-DL vs WEBRip, audio preservation (DD5.1 vs AAC), HDR bonus, 10-bit bonus, different-resolution fallback, complex filename parsing, and file-size parsing (GB/MB/KB).
- `test_quality_standalone.py` — standalone script for manual verification without full dependency setup.

### Backward compatibility

- Different resolutions still use the original always-replace logic — no behavior change there.
- Same-resolution replacements now go through the quality hierarchy check instead of unconditional overwrite.
- No schema changes; works with existing `quality`/`name`/`size` fields already stored per entry.

### Docs included

`QUALITY_HIERARCHY.md` (full spec + scoring tables + example logs), `IMPLEMENTATION_SUMMARY.md`, `BEFORE_VS_AFTER.md`, `quality-hierarchy-README.md`.

### Known limitations

- Detection is filename-based only (no actual media inspection via ffprobe).
- Requires reasonably standard naming conventions (PTN-style) to detect quality tags.
- Unknown/unrecognized tags simply score 0 in that category rather than failing.

[QUALITY_HIERARCHY.md](https://github.com/user-attachments/files/30222422/QUALITY_HIERARCHY.md)
[IMPLEMENTATION_SUMMARY.md](https://github.com/user-attachments/files/30222429/IMPLEMENTATION_SUMMARY.md)
[BEFORE_VS_AFTER.md](https://github.com/user-attachments/files/30222436/BEFORE_VS_AFTER.md)
[quality-hierarchy-README.md](https://github.com/user-attachments/files/30222443/quality-hierarchy-README.md)
