### PR TITLE
fix: multi-currency plans, single-zip movies, announce auto-delete, search quality badges

### DIFF
--- a/Backend/__init__.py
+++ b/Backend/__init__.py
@@ -14,4 +14,4 @@ USE_DEFAULT_ID: str = None
 MANUAL_SESSION: dict = None
 db = Database()
 
-__version__ = "4.8.1"
+__version__ = "4.8.2"

--- a/Backend/fastapi/routes/api_routes.py
+++ b/Backend/fastapi/routes/api_routes.py
@@ -70,6 +70,7 @@ from Backend.helper.subtitles import (
     remove_subtitle,
     resolve_subtitle_message,
 )
+from Backend.helper.announcer import delete_announcement_async
 from Backend.logger import LOGGER
 import Backend.pyrofork.bot as botmod
 from Backend.pyrofork.bot import (
@@ -162,6 +163,8 @@ async def delete_media_api(
         media_type_formatted = "Movie" if media_type == "movie" else "Series"
         result = await db.delete_document(media_type_formatted, tmdb_id, db_index)
         if result:
+            # Remove matching announcement post from the announcement channel
+            delete_announcement_async(media_type, tmdb_id)
             return {"message": "Media deleted successfully"}
         else:
             raise HTTPException(status_code=404, detail="Media not found")
@@ -649,10 +652,11 @@ async def add_subscription_plan_api(payload: dict) -> dict:
     try:
         days = int(payload.get("days", 0))
         price = float(payload.get("price", 0.0))
+        currency = str(payload.get("currency") or "INR").upper().strip()
         if days <= 0 or price < 0:
             raise HTTPException(status_code=400, detail="Invalid plan parameters")
             
-        plan_id = await db.add_subscription_plan(days, price)
+        plan_id = await db.add_subscription_plan(days, price, currency)
         if plan_id:
             return {"status": "success", "message": "Plan added successfully", "plan_id": plan_id}
         else:
@@ -666,10 +670,11 @@ async def update_subscription_plan_api(plan_id: str, payload: dict) -> dict:
     try:
         days = int(payload.get("days", 0))
         price = float(payload.get("price", 0.0))
+        currency = str(payload.get("currency") or "INR").upper().strip()
         if days <= 0 or price < 0:
              raise HTTPException(status_code=400, detail="Invalid plan parameters")
              
-        success = await db.update_subscription_plan(plan_id, days, price)
+        success = await db.update_subscription_plan(plan_id, days, price, currency)
         if success:
              return {"status": "success", "message": "Plan updated successfully"}
         else:

--- a/Backend/fastapi/templates/access_manage.html
+++ b/Backend/fastapi/templates/access_manage.html
@@ -564,7 +564,7 @@
             const sel = document.getElementById('assign-plan-select');
             if (!sel) return;
             sel.innerHTML = '<option value="">— Select a plan —</option>' +
-                plans.map(p => `<option value="${p.days}">${p.days} days${p.price ? ' — ₹' + p.price : ''}</option>`).join('');
+                plans.map(p => { const sym = ({INR:'₹',USD:'$',EUR:'€',GBP:'£',JPY:'¥',AUD:'A$',CAD:'C$',SGD:'S$',AED:'د.إ',BRL:'R$'}[(p.currency||'INR').toUpperCase()]||((p.currency||'INR')+' ')); return `<option value="${p.days}">${p.days} days${p.price != null ? ' — ' + sym + p.price : ''}</option>`; }).join('');
         } catch (e) { /* ignore */ }
     }
 

--- a/Backend/fastapi/templates/subscriptions_manage.html
+++ b/Backend/fastapi/templates/subscriptions_manage.html
@@ -521,8 +521,23 @@
             </div>
 
             <div class="modal-field">
-                <label for="plan-price">Price (₹)</label>
+                <label for="plan-price">Price</label>
                 <input type="number" id="plan-price" class="glass-input" required min="0" step="0.01">
+            </div>
+            <div>
+                <label for="plan-currency">Currency</label>
+                <select id="plan-currency" class="glass-input">
+                    <option value="INR">INR (₹)</option>
+                    <option value="USD">USD ($)</option>
+                    <option value="EUR">EUR (€)</option>
+                    <option value="GBP">GBP (£)</option>
+                    <option value="JPY">JPY (¥)</option>
+                    <option value="AUD">AUD (A$)</option>
+                    <option value="CAD">CAD (C$)</option>
+                    <option value="SGD">SGD (S$)</option>
+                    <option value="AED">AED (د.إ)</option>
+                    <option value="BRL">BRL (R$)</option>
+                </select>
             </div>
 
             <div class="flex flex-col-reverse sm:flex-row justify-end gap-3 pt-2">
@@ -637,7 +652,7 @@
             container.innerHTML = plans.map(p => `
                 <div class="plan-card p-5 sm:p-6">
                     <div class="plan-actions absolute right-4 top-4 flex gap-2">
-                        <button onclick="openPlanModal('${p._id}', ${p.days}, ${p.price})"
+                        <button onclick="openPlanModal('${p._id}', ${p.days}, ${p.price}, '${p.currency || 'INR'}')"
                             class="glass-btn rounded-full w-9 h-9 flex items-center justify-center" title="Edit plan">
                             <i class="fas fa-pen text-sm"></i>
                         </button>
@@ -655,7 +670,8 @@
 
                         <div class="min-w-0">
                             <div class="text-sm font-semibold section-muted">${p.days} Days Plan</div>
-                            <div class="mt-1 text-3xl font-extrabold section-title tracking-tight">₹${p.price}</div>
+                            <div class="mt-1 text-3xl font-extrabold section-title tracking-tight">${currencySymbol(p.currency)}${p.price}</div>
+                    <div class="text-xs text-soft mt-0.5">${(p.currency || 'INR').toUpperCase()}</div>
                             <div class="mt-3 inline-flex items-center gap-2 text-xs font-bold rounded-full px-3 py-1"
                                  style="background: color-mix(in srgb, var(--accent) 12%, transparent); color: var(--text-sec); border: 1px solid color-mix(in srgb, var(--accent) 20%, transparent);">
                                 <i class="fas fa-bolt" style="color: var(--accent);"></i>
@@ -675,10 +691,17 @@
         }
     }
 
-    function openPlanModal(id = '', days = '', price = '') {
+    function currencySymbol(code) {
+        const map = {INR:'₹',USD:'$',EUR:'€',GBP:'£',JPY:'¥',AUD:'A$',CAD:'C$',SGD:'S$',AED:'د.إ',BRL:'R$'};
+        return map[(code || 'INR').toUpperCase()] || ((code || 'INR') + ' ');
+    }
+
+    function openPlanModal(id = '', days = '', price = '', currency = 'INR') {
         document.getElementById('plan-id').value = id;
         document.getElementById('plan-days').value = days;
         document.getElementById('plan-price').value = price;
+        const cur = document.getElementById('plan-currency');
+        if (cur) cur.value = (currency || 'INR').toUpperCase();
         document.getElementById('plan-modal-title').innerText = id ? 'Edit Plan' : 'Add New Plan';
 
         const modal = document.getElementById('plan-modal');
@@ -700,7 +723,8 @@
         const id = document.getElementById('plan-id').value;
         const payload = {
             days: parseInt(document.getElementById('plan-days').value),
-            price: parseFloat(document.getElementById('plan-price').value)
+            price: parseFloat(document.getElementById('plan-price').value),
+            currency: (document.getElementById('plan-currency') || {}).value || 'INR'
         };
 
         try {

--- a/Backend/helper/announcer.py
+++ b/Backend/helper/announcer.py
@@ -2,7 +2,7 @@ from asyncio import create_task
 from datetime import datetime
 
 from pyrogram.enums import ParseMode
-from pyrogram.errors import FloodWait
+from pyrogram.errors import FloodWait, MessageDeleteForbidden, MessageIdInvalid
 from pyrogram.types import InlineKeyboardButton, InlineKeyboardMarkup
 
 from Backend import db
@@ -22,7 +22,7 @@ def _resolve_chat(value: str):
         return value
 
 
-#----- Atomically claim a title so it is announced at most once
+#----- Atomically claim a title so it is announced at most once; returns True if newly claimed
 async def _claim(media_type: str, tmdb_id) -> bool:
     if not tmdb_id:
         return False
@@ -32,6 +32,19 @@ async def _claim(media_type: str, tmdb_id) -> bool:
         upsert=True,
     )
     return result.upserted_id is not None
+
+
+async def _store_announcement_msg(media_type: str, tmdb_id, chat_id, message_id: int) -> None:
+    if not tmdb_id or not message_id:
+        return
+    try:
+        await db.dbs["tracking"]["announced"].update_one(
+            {"_id": f"{media_type}:{tmdb_id}"},
+            {"$set": {"chat_id": chat_id, "message_id": message_id, "at": datetime.utcnow()}},
+            upsert=True,
+        )
+    except Exception as e:
+        LOGGER.warning(f"Failed to store announcement message id: {e}")
 
 
 def _build_caption(info: dict) -> str:
@@ -90,17 +103,20 @@ async def _announce(info: dict) -> None:
     markup = _build_markup(info)
 
     try:
+        sent = None
         if poster:
             try:
-                await StreamBot.send_photo(chat, poster, caption=caption,
+                sent = await StreamBot.send_photo(chat, poster, caption=caption,
                                            parse_mode=ParseMode.HTML, reply_markup=markup)
-                return
             except FloodWait:
                 raise
             except Exception:
-                pass
-        await StreamBot.send_message(chat, caption, parse_mode=ParseMode.HTML,
+                sent = None
+        if sent is None:
+            sent = await StreamBot.send_message(chat, caption, parse_mode=ParseMode.HTML,
                                      reply_markup=markup, disable_web_page_preview=True)
+        if sent is not None:
+            await _store_announcement_msg(info.get("media_type"), info.get("tmdb_id"), chat, sent.id)
     except FloodWait as e:
         LOGGER.warning(f"Announcement FloodWait for {e.value}s")
     except Exception as e:
@@ -113,3 +129,37 @@ def announce_new_media(info: dict) -> None:
         create_task(_announce(dict(info)))
     except RuntimeError:
         LOGGER.warning("Announcement skipped: no running event loop.")
+
+
+#----- Delete the announcement message when media is removed from the library
+async def delete_announcement(media_type: str, tmdb_id) -> None:
+    if not tmdb_id:
+        return
+    key = f"{media_type}:{tmdb_id}"
+    try:
+        doc = await db.dbs["tracking"]["announced"].find_one_and_delete({"_id": key})
+    except Exception as e:
+        LOGGER.warning(f"Failed to lookup announcement for {key}: {e}")
+        return
+    if not doc:
+        return
+    chat_id = doc.get("chat_id")
+    message_id = doc.get("message_id")
+    if not chat_id or not message_id:
+        return
+    try:
+        await StreamBot.delete_messages(chat_id, message_id)
+        LOGGER.info(f"Deleted announcement message {message_id} for {key}")
+    except (MessageDeleteForbidden, MessageIdInvalid) as e:
+        LOGGER.warning(f"Could not delete announcement {message_id} for {key}: {e}")
+    except FloodWait as e:
+        LOGGER.warning(f"FloodWait deleting announcement for {key}: {e.value}s")
+    except Exception as e:
+        LOGGER.warning(f"Failed to delete announcement message for {key}: {e}")
+
+
+def delete_announcement_async(media_type: str, tmdb_id) -> None:
+    try:
+        create_task(delete_announcement(media_type, tmdb_id))
+    except RuntimeError:
+        LOGGER.warning("Announcement delete skipped: no running event loop.")

--- a/Backend/helper/database.py
+++ b/Backend/helper/database.py
@@ -287,11 +287,12 @@ class Database:
             upsert=True
         )
 
-    async def set_pending_payment(self, user_id: int, plan_duration: int, msg_id: int, price=0, admin_messages: list = None):
+    async def set_pending_payment(self, user_id: int, plan_duration: int, msg_id: int, price=0, admin_messages: list = None, currency: str = "INR"):
         update_data = {
             "pending_payment": {
                 "duration": plan_duration,
                 "price": price,
+                "currency": (currency or "INR").upper(),
                 "msg_id": msg_id,
                 "date": datetime.utcnow(),
             }
@@ -372,19 +373,20 @@ class Database:
         plans = await cursor.to_list(None)
         return [convert_objectid_to_str(plan) for plan in plans]
 
-    async def add_subscription_plan(self, days: int, price: float) -> Optional[str]:
+    async def add_subscription_plan(self, days: int, price: float, currency: str = "INR") -> Optional[str]:
         result = await self.dbs["tracking"]["sub_plans"].insert_one({
             "days": days,
             "price": price,
+            "currency": (currency or "INR").upper(),
             "created_at": datetime.utcnow()
         })
         return str(result.inserted_id)
 
-    async def update_subscription_plan(self, plan_id: str, days: int, price: float) -> bool:
+    async def update_subscription_plan(self, plan_id: str, days: int, price: float, currency: str = "INR") -> bool:
         try:
             result = await self.dbs["tracking"]["sub_plans"].update_one(
                 {"_id": ObjectId(plan_id)},
-                {"$set": {"days": days, "price": price, "updated_at": datetime.utcnow()}}
+                {"$set": {"days": days, "price": price, "currency": (currency or "INR").upper(), "updated_at": datetime.utcnow()}}
             )
             return result.modified_count > 0
         except Exception:
@@ -1664,7 +1666,7 @@ class Database:
                 {"$project": {
                     "_id": 1, "tmdb_id": 1, "title": 1, "genres": 1, "rating": 1, "imdb_id": 1,
                     "release_year": 1, "poster": 1, "backdrop": 1, "description": 1, "logo": 1,
-                    "media_type": 1, "db_index": 1
+                    "media_type": 1, "db_index": 1, "seasons": 1
                 }}
             ]
             
@@ -1673,7 +1675,7 @@ class Database:
                 {"$project": {
                     "_id": 1, "tmdb_id": 1, "title": 1, "genres": 1, "rating": 1,
                     "release_year": 1, "poster": 1, "backdrop": 1, "description": 1,
-                    "media_type": 1, "db_index": 1, "imdb_id": 1, "logo": 1
+                    "media_type": 1, "db_index": 1, "imdb_id": 1, "logo": 1, "telegram": 1
                 }}
             ]
             

--- a/Backend/helper/global_search.py
+++ b/Backend/helper/global_search.py
@@ -165,7 +165,8 @@ def _video_filename(message) -> Optional[str]:
     if message.document:
         mime = message.document.mime_type or ""
         name = message.document.file_name
-        if mime.startswith("video/") or (name and name.lower().endswith(_VIDEO_EXTS)):
+        # Include single .zip archives (STORED inner video is streamable)
+        if mime.startswith("video/") or (name and (name.lower().endswith(_VIDEO_EXTS) or name.lower().endswith(".zip"))):
             return (message.caption or "").strip() or name or "video.mkv"
     return None
 
@@ -338,7 +339,8 @@ async def _search_channel(
                     size = get_readable_file_size(getattr(media, "file_size", 0) or 0)
                     quality = parsed.get("resolution") or "HD"
 
-                    token = await encode_string({
+                    is_single_zip = bool(filename and filename.lower().endswith(".zip"))
+                    payload = {
                         "global": True,
                         "chat_id": chat_id,
                         "msg_id": message.id,
@@ -346,7 +348,14 @@ async def _search_channel(
                         "size": size,
                         "quality": quality,
                         "source": chat_title,
-                    })
+                    }
+                    if is_single_zip:
+                        # Represent as a one-part zip so stream routes use the zip path
+                        payload["zip"] = True
+                        payload["parts"] = [{"chat_id": chat_id, "msg_id": message.id}]
+                        del payload["chat_id"]
+                        del payload["msg_id"]
+                    token = await encode_string(payload)
 
                     results.append({
                         "token": token,
@@ -354,6 +363,7 @@ async def _search_channel(
                         "size": size,
                         "source_chat": chat_title,
                         "quality": quality,
+                        "is_zip": is_single_zip,
                     })
                     LOGGER.debug(f"[GLOBAL SEARCH] Result found: {filename} in {chat_title}")
 

--- a/Backend/helper/metadata.py
+++ b/Backend/helper/metadata.py
@@ -817,6 +817,13 @@ async def metadata(filename: str, channel: int, msg_id, override_id: str = None,
         encoded_string = None
 
     group_key = f"{channel}:{quality}:{split_info[0]}" if split_info else None
+    # Single (non-split) .zip archives: treat as a one-part zip so streaming
+    # can extract and seek the inner STORED video the same way as .zip.001 sets.
+    if group_key is None and filename and filename.lower().rstrip().endswith(".zip"):
+        from Backend.helper.split_files import _normalize
+        base = filename.rsplit(".", 1)[0]
+        group_key = f"{channel}:{quality}:{_normalize(base)}.zip"
+        part_number = 1
     anime_channel = _is_anime_channel(channel)
 
     try:

--- a/Backend/pyrofork/plugins/receiver.py
+++ b/Backend/pyrofork/plugins/receiver.py
@@ -38,6 +38,10 @@ def _is_supported_media(message: Message) -> bool:
         candidate = message.caption or message.document.file_name or ""
         if parse_split_info(candidate):
             return True
+        # Single (non-split) STORED zip archives containing a video
+        name = (message.document.file_name or candidate or "").lower()
+        if name.endswith(".zip") and not parse_split_info(name):
+            return True
     return False
 
 

--- a/Backend/pyrofork/plugins/start.py
+++ b/Backend/pyrofork/plugins/start.py
@@ -8,6 +8,10 @@ from Backend.config import Telegram
 from Backend.helper.settings_manager import SettingsManager
 from Backend.logger import LOGGER
 
+def _currency_symbol(code):
+    return {"INR": "₹", "USD": "$", "EUR": "€", "GBP": "£", "JPY": "¥", "AUD": "A$", "CAD": "C$", "SGD": "S$", "AED": "د.إ", "BRL": "R$"}.get((code or "INR").upper(), f"{(code or 'INR')} ")
+
+
 
 #----- /start: hand out the Stremio addon link, gated by subscription state
 @Client.on_message(filters.command('start') & filters.private, group=10)
@@ -65,7 +69,7 @@ async def send_start_message(client: Client, message: Message):
                 )
 
             keyboard = InlineKeyboardMarkup([
-                [InlineKeyboardButton(f"{plan['days']} Days - ₹{plan['price']}", callback_data=f"plan_{plan['_id']}")]
+                [InlineKeyboardButton(f"{plan['days']} Days - {_currency_symbol(plan.get('currency'))}{plan['price']}", callback_data=f"plan_{plan['_id']}")]
                 for plan in plans
             ])
             return await message.reply_text(

--- a/Backend/pyrofork/plugins/subscription.py
+++ b/Backend/pyrofork/plugins/subscription.py
@@ -14,6 +14,10 @@ from Backend.config import Telegram
 from Backend.helper.settings_manager import SettingsManager
 from Backend.logger import LOGGER
 
+def _currency_symbol(code):
+    return {"INR": "₹", "USD": "$", "EUR": "€", "GBP": "£", "JPY": "¥", "AUD": "A$", "CAD": "C$", "SGD": "S$", "AED": "د.إ", "BRL": "R$"}.get((code or "INR").upper(), f"{(code or 'INR')} ")
+
+
 
 #----- Configured approvers, falling back to the owner
 def _approver_ids() -> list:
@@ -30,12 +34,13 @@ async def _resolve_target_info(client: Client, target_user_id: int):
 
 
 #----- Formatted plan/user block shared by approve and reject captions
-def _plan_info_text(mention: str, username_str: str, user_id: int, duration, price) -> str:
+def _plan_info_text(mention: str, username_str: str, user_id: int, duration, price, currency="INR") -> str:
+    sym = _currency_symbol(currency)
     return (
         f"👤 <b>User:</b> {mention}\n"
         f"🆔 <b>User ID:</b> <code>{user_id}</code>\n"
         f"🔗 <b>Username:</b> {username_str}\n\n"
-        f"📦 <b>Plan:</b> {duration} days (₹{price})"
+        f"📦 <b>Plan:</b> {duration} days ({sym}{price})"
     )
 
 
@@ -88,24 +93,24 @@ async def plan_selection(client: Client, callback_query: CallbackQuery):
 
     text = (
         f"<b>✅ Plan Selected: {plan['days']} Days</b>\n\n"
-        f"<b>💰 Price:</b> ₹{plan['price']}\n"
+        f"<b>💰 Price:</b> {_currency_symbol(plan.get('currency'))}{plan['price']}\n"
         f"<b>📅 Expiry (if approved now):</b> {expiry_str}\n\n"
         f"<b>📋 How to Pay:</b>\n"
     )
-    text += f"{payment_instructions}\n\n" if payment_instructions else f"Pay ₹{plan['price']} to the admin.\n\n"
+    text += f"{payment_instructions}\n\n" if payment_instructions else f"Pay {_currency_symbol(plan.get('currency'))}{plan['price']} to the admin.\n\n"
     text += (
         "<b>After paying:</b> send your payment screenshot directly here "
         "(in this chat). The admin will review and activate your subscription."
     )
 
-    await db.set_pending_payment(user_id, int(duration), 0, price=plan.get("price", 0))
+    await db.set_pending_payment(user_id, int(duration), 0, price=plan.get("price", 0), currency=plan.get("currency", "INR"))
 
     #----- Prefer DMing the user so the private screenshot handler can pick it up
     dm_sent = False
     try:
         if payment_qr_url:
             try:
-                await client.send_photo(chat_id=user_id, photo=payment_qr_url, caption=f"📷 Scan to pay ₹{plan['price']}")
+                await client.send_photo(chat_id=user_id, photo=payment_qr_url, caption=f"📷 Scan to pay {_currency_symbol(plan.get('currency'))}{plan['price']}")
             except Exception as qe:
                 LOGGER.warning(f"Could not send payment QR to {user_id}: {qe}")
         await client.send_message(chat_id=user_id, text=text, reply_markup=ForceReply(selective=True))
@@ -150,6 +155,7 @@ async def handle_payment_screenshot(client: Client, message: Message):
         pending = user["pending_payment"]
         duration = pending.get("duration", "?")
         price = pending.get("price", "?")
+        currency = pending.get("currency", "INR")
 
         keyboard = InlineKeyboardMarkup([[
             InlineKeyboardButton("✅ Approve", callback_data=f"approve_{sender_id}"),
@@ -166,7 +172,7 @@ async def handle_payment_screenshot(client: Client, message: Message):
             f"<b>🔗 Username:</b> {username_str}\n\n"
             f"<b>📦 Plan Details:</b>\n"
             f"  • Duration: <b>{duration} days</b>\n"
-            f"  • Price: <b>₹{price}</b>\n\n"
+            f"  • Price: <b>{_currency_symbol(currency)}{price}</b>\n\n"
             f"Please review the screenshot above and approve or reject."
         )
 
@@ -178,7 +184,7 @@ async def handle_payment_screenshot(client: Client, message: Message):
             except Exception as e:
                 LOGGER.error(f"Failed to forward screenshot to approver {approver_id}: {e}")
 
-        await db.set_pending_payment(sender_id, duration, message.id, price=price, admin_messages=admin_messages)
+        await db.set_pending_payment(sender_id, duration, message.id, price=price, admin_messages=admin_messages, currency=currency)
 
         if admin_messages:
             await message.reply_text(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Telegram-Stremio"
-version = "4.8.1"
+version = "4.8.2"
 description = "A powerful, self-hosted Telegram Stremio Media Server built with FastAPI, MongoDB, and PyroFork seamlessly integrated with Stremio for automated media streaming and discovery."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -1076,7 +1076,7 @@ wheels = [
 
 [[package]]
 name = "telegram-stremio"
-version = "4.8.1"
+version = "4.8.2"
 source = { virtual = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Fixes four issues against `master`:

1. **Multiple currency formats in subscription plans** — `currency` field (INR/USD/EUR/GBP/JPY/AUD/CAD/SGD/AED/BRL) with symbols in admin UI, access page, and bot messages.
2. **Zip support for normal (non-split) movies** — single `.zip` (not only `.zip.001`) indexed and streamable when STORED/uncompressed.
3. **Auto-delete announcement on media delete** — deleting a title from Media Management removes the related announcement message.
4. **Quality & size badges on Media Management search** — search results include `telegram`/`seasons` so badges match the normal list.

## Commits on `dev` so far

| File | Status |
|------|--------|
| `Backend/helper/announcer.py` | ✅ pushed |
| `Backend/pyrofork/plugins/start.py` | ✅ pushed |
| Remaining 8 files | ⏳ apply from local patch (see below) |

## Finish the remaining files (on your machine)

```bash
git clone https://github.com/weebzone/Telegram-Stremio.git
cd Telegram-Stremio
git checkout dev
# Apply the full patch from the conversation artifacts, or copy from Telegram-Stremio-dev/
git add -A
git commit -m "fix: remaining multi-currency, zip, search, and API hooks"
git push origin dev
```

Or mark this draft ready once all files are on `dev`.

## Test plan

- [ ] Plans with different currencies show correct symbols (admin, access, bot `/start`)
- [ ] Single STORED `.zip` indexes and seeks
- [ ] Delete media → announcement message deleted
- [ ] Media Management search shows quality + size badges
